### PR TITLE
Remove stray code after class definition

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -51,11 +51,3 @@ class FileLinkUsageScanner {
 
 }
 
-$this->database->insert('filelink_usage_matches')
-  ->fields([
-    'nid' => $node->id(),
-    'link' => $match,
-    'timestamp' => \Drupal::time()->getRequestTime(),
-  ])
-  ->execute();
-


### PR DESCRIPTION
## Summary
- remove stray database insert from FileLinkUsageScanner so no code executes at file scope

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf68686288331a27bed01ab99c608