### PR TITLE
Add Drush service definition

### DIFF
--- a/filelink_usage.drush.services.yml
+++ b/filelink_usage.drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  filelink_usage.commands:
+    class: Drupal\filelink_usage\Commands\FileLinkUsageCommands
+    arguments: ['@filelink_usage.scanner']
+    tags:
+      - { name: drush.command }

--- a/filelink_usage.info.yml
+++ b/filelink_usage.info.yml
@@ -6,8 +6,4 @@ package: Custom
 dependencies:
   - file
   - node
-drush.services:
-  filelink_usage:
-    commands:
-      - Drupal\filelink_usage\Commands\FileLinkUsageCommands
 


### PR DESCRIPTION
## Summary
- add `filelink_usage.drush.services.yml` defining the Drush command service
- clean up `drush.services` section from `filelink_usage.info.yml`

## Testing
- `drush filelink_usage:scan` *(fails: `drush` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf75698b483319e14a50b33a0e54f