### PR TITLE
Implement file usage scanning

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -36,6 +36,33 @@ class FileLinkUsageScanner {
           $text = $field->value;
           preg_match_all('/(public:\/\/[^\s"\']+|\/sites\/default\/files\/[^\s"\']+|https?:\/\/[^\/"]+\/sites\/default\/files\/[^\s"\']+)/i', $text, $matches);
           foreach ($matches[0] as $match) {
+            $uri = $match;
+            if (preg_match('#https?://[^/]+(/sites/default/files/.*)#i', $uri, $m)) {
+              $uri = $m[1];
+            }
+            if (strpos($uri, '/sites/default/files/') === 0) {
+              $uri = 'public://' . substr($uri, strlen('/sites/default/files/'));
+            }
+
+            $file_storage = $this->entityTypeManager->getStorage('file');
+            $file = $file_storage->loadByProperties(['uri' => $uri]);
+            $file = $file ? reset($file) : NULL;
+
+            if ($file) {
+              $usage = $this->fileUsage->listUsage($file);
+              if (empty($usage['filelink_usage']['node'][$node->id()])) {
+                $this->fileUsage->add($file, 'filelink_usage', 'node', $node->id());
+              }
+            }
+
+            $this->database->insert('filelink_usage_matches')
+              ->fields([
+                'nid' => $node->id(),
+                'link' => $match,
+                'timestamp' => time(),
+              ])
+              ->execute();
+
             $results[] = [
               'nid' => $node->id(),
               'link' => $match,


### PR DESCRIPTION
## Summary
- track usage of hard-coded file links

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf9b3d6bc8331a40cee5aa47a1332