### PR TITLE
Implement module hooks for file scanning

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -1,0 +1,111 @@
+<?php
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_cron().
+ */
+function filelink_usage_cron() {
+  \Drupal::service('filelink_usage.scanner')->scan();
+}
+
+/**
+ * Scan a single node for file links and update usage.
+ */
+function filelink_usage_rescan_node(NodeInterface $node) {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $file_usage = \Drupal::service('file.usage');
+  $database = \Drupal::database();
+
+  foreach ($node->getFields() as $field) {
+    $type = $field->getFieldDefinition()->getType();
+    if ($type === 'text_long' || $type === 'text_with_summary') {
+      $text = $field->value;
+      preg_match_all('/(public:\/\/[^\s"\']+|\/sites\/default\/files\/[^\s"\']+|https?:\/\/[^\/"]+\/sites\/default\/files\/[^\s"\']+)/i', $text, $matches);
+      foreach ($matches[0] as $match) {
+        $uri = $match;
+        if (preg_match('#https?://[^/]+(/sites/default/files/.*)#i', $uri, $m)) {
+          $uri = $m[1];
+        }
+        if (strpos($uri, '/sites/default/files/') === 0) {
+          $uri = 'public://' . substr($uri, strlen('/sites/default/files/'));
+        }
+
+        $file_storage = $entity_type_manager->getStorage('file');
+        $files = $file_storage->loadByProperties(['uri' => $uri]);
+        $file = $files ? reset($files) : NULL;
+
+        if ($file) {
+          $usage = $file_usage->listUsage($file);
+          if (empty($usage['filelink_usage']['node'][$node->id()])) {
+            $file_usage->add($file, 'filelink_usage', 'node', $node->id());
+          }
+        }
+
+        $database->insert('filelink_usage_matches')
+          ->fields([
+            'nid' => $node->id(),
+            'link' => $match,
+            'timestamp' => time(),
+          ])
+          ->execute();
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function filelink_usage_entity_insert(EntityInterface $entity) {
+  if ($entity instanceof NodeInterface) {
+    filelink_usage_rescan_node($entity);
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function filelink_usage_entity_update(EntityInterface $entity) {
+  if ($entity instanceof NodeInterface) {
+    filelink_usage_rescan_node($entity);
+  }
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function filelink_usage_entity_delete(EntityInterface $entity) {
+  if ($entity instanceof NodeInterface) {
+    $database = \Drupal::database();
+    $file_usage = \Drupal::service('file.usage');
+    $entity_type_manager = \Drupal::entityTypeManager();
+
+    $links = $database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('nid', $entity->id())
+      ->execute()
+      ->fetchCol();
+
+    foreach ($links as $link) {
+      $uri = $link;
+      if (preg_match('#https?://[^/]+(/sites/default/files/.*)#i', $uri, $m)) {
+        $uri = $m[1];
+      }
+      if (strpos($uri, '/sites/default/files/') === 0) {
+        $uri = 'public://' . substr($uri, strlen('/sites/default/files/'));
+      }
+      $file_storage = $entity_type_manager->getStorage('file');
+      $files = $file_storage->loadByProperties(['uri' => $uri]);
+      $file = $files ? reset($files) : NULL;
+      if ($file) {
+        $file_usage->delete($file, 'filelink_usage', 'node', $entity->id());
+      }
+    }
+
+    $database->delete('filelink_usage_matches')
+      ->condition('nid', $entity->id())
+      ->execute();
+  }
+}


### PR DESCRIPTION
## Summary
- add `filelink_usage.module` with cron and entity hooks

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bfa823b7083319bb6cf81192d9724