### PR TITLE
Add uninstall hook to remove table and config

### DIFF
--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -35,3 +35,16 @@ function filelink_usage_schema() {
   ];
   return $schema;
 }
+
+/**
+ * Implements hook_uninstall().
+ */
+function filelink_usage_uninstall() {
+  $schema = \Drupal::database()->schema();
+  if ($schema->tableExists('filelink_usage_matches')) {
+    $schema->dropTable('filelink_usage_matches');
+  }
+
+  // Remove module configuration if present.
+  \Drupal::configFactory()->getEditable('filelink_usage.settings')->delete();
+}


### PR DESCRIPTION
## Summary
- implement hook_uninstall to drop `filelink_usage_matches`
- clear module config during uninstall

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bfc42e5ec833197eb1d98fd379bfb