### PR TITLE
Enable verbose logging by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The `filelink_usage` module scans all text fields across your Drupal 10/11 site�
 - ⏱️ Automatically scans during Drupal cron runs
 - 💾 Save hooks keep file usage in sync on node create, update, and delete
 - 💻 `drush filelink_usage:scan` command to run the scanner manually
-- ⚙️ Configuration form with optional verbose logging (available once the settings form is implemented)
+- ⚙️ Configuration form with verbose logging enabled by default
 
 ## Use Cases
 

--- a/config/install/filelink_usage.settings.yml
+++ b/config/install/filelink_usage.settings.yml
@@ -1,1 +1,1 @@
-verbose_logging: false
+verbose_logging: true


### PR DESCRIPTION
## Summary
- make verbose logging default in `filelink_usage.settings.yml`
- update README to note that verbose logging is enabled by default

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0a9da6b48331926648cb5ab99d4d