### PR TITLE
Add purge button for file links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The `filelink_usage` module scans all text fields across your Drupal 10 or 11 si
 - 💾 Save hooks keep file usage in sync on node create, update, and delete
 - 💻 `drush filelink_usage:scan` command to run the scanner manually
 - ⚙️ Configuration form with verbose logging enabled by default
+- 🧹 Admin UI button to purge stored file link matches
 
 ## Use Cases
 

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -4,6 +4,7 @@ namespace Drupal\filelink_usage\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal;
 
 /**
  * Configure File Link Usage settings.
@@ -37,6 +38,15 @@ class SettingsForm extends ConfigFormBase {
       '#description' => $this->t('Write detailed entries to the File Link Usage log channel.'),
     ];
 
+    $form['actions']['purge'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Purge saved file links'),
+      '#submit' => ['::purgeFileLinkMatches'],
+      '#limit_validation_errors' => [],
+      '#button_type' => 'danger',
+      '#weight' => 10,
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -49,6 +59,15 @@ class SettingsForm extends ConfigFormBase {
       ->save();
 
     parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Purges saved file link matches from the database.
+   */
+  public function purgeFileLinkMatches(array &$form, FormStateInterface $form_state) {
+    Drupal::database()->truncate('filelink_usage_matches')->execute();
+    $this->messenger()->addMessage($this->t('All saved file links have been purged.'));
+    $form_state->setRebuild();
   }
 
 }


### PR DESCRIPTION
## Summary
- add a UI button to purge stored file links
- document new purge capability in README

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c143467a0833182602266a6db1062