### PR TITLE
Add unique key and deduplicate link scanning

### DIFF
--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -32,6 +32,9 @@ function filelink_usage_schema() {
       'nid' => ['nid'],
       'link' => ['link'],
     ],
+    'unique keys' => [
+      'nid_link' => ['nid', 'link'],
+    ],
   ];
   return $schema;
 }
@@ -47,4 +50,14 @@ function filelink_usage_uninstall() {
 
   // Remove module configuration if present.
   \Drupal::configFactory()->getEditable('filelink_usage.settings')->delete();
+}
+
+/**
+ * Add a unique key on nid and link.
+ */
+function filelink_usage_update_8001() {
+  $schema = \Drupal::database()->schema();
+  if ($schema->tableExists('filelink_usage_matches') && !$schema->indexExists('filelink_usage_matches', 'nid_link')) {
+    $schema->addUniqueKey('filelink_usage_matches', 'nid_link', ['nid', 'link']);
+  }
 }

--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -43,10 +43,12 @@ function filelink_usage_rescan_node(NodeInterface $node) {
           }
         }
 
-        $database->insert('filelink_usage_matches')
-          ->fields([
+        $database->merge('filelink_usage_matches')
+          ->key([
             'nid' => $node->id(),
             'link' => $match,
+          ])
+          ->fields([
             'timestamp' => time(),
           ])
           ->execute();

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -59,10 +59,12 @@ class FileLinkUsageScanner {
               }
             }
 
-            $this->database->insert('filelink_usage_matches')
-              ->fields([
+            $this->database->merge('filelink_usage_matches')
+              ->key([
                 'nid' => $node->id(),
                 'link' => $match,
+              ])
+              ->fields([
                 'timestamp' => time(),
               ])
               ->execute();


### PR DESCRIPTION
## Summary
- add unique `(nid, link)` constraint to schema
- provide update hook for existing installs
- use `merge()` in scanners to avoid duplicate entries

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c13dad7b08331bc43606c535688bb