### PR TITLE
Add scan status table and selective cron scanning

### DIFF
--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -36,6 +36,22 @@ function filelink_usage_schema() {
       'nid_link' => ['nid', 'link'],
     ],
   ];
+
+  $schema['filelink_usage_scan_status'] = [
+    'description' => 'Tracks the last successful scan time for each node.',
+    'fields' => [
+      'nid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'scanned' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['nid'],
+  ];
   return $schema;
 }
 
@@ -46,6 +62,9 @@ function filelink_usage_uninstall() {
   $schema = \Drupal::database()->schema();
   if ($schema->tableExists('filelink_usage_matches')) {
     $schema->dropTable('filelink_usage_matches');
+  }
+  if ($schema->tableExists('filelink_usage_scan_status')) {
+    $schema->dropTable('filelink_usage_scan_status');
   }
 
   // Remove module configuration if present.
@@ -59,5 +78,29 @@ function filelink_usage_update_8001() {
   $schema = \Drupal::database()->schema();
   if ($schema->tableExists('filelink_usage_matches') && !$schema->indexExists('filelink_usage_matches', 'nid_link')) {
     $schema->addUniqueKey('filelink_usage_matches', 'nid_link', ['nid', 'link']);
+  }
+}
+
+/**
+ * Create scan status table.
+ */
+function filelink_usage_update_8002() {
+  $schema = \Drupal::database()->schema();
+  if (!$schema->tableExists('filelink_usage_scan_status')) {
+    $schema->createTable('filelink_usage_scan_status', [
+      'description' => 'Tracks the last successful scan time for each node.',
+      'fields' => [
+        'nid' => [
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+        ],
+        'scanned' => [
+          'type' => 'int',
+          'not null' => TRUE,
+        ],
+      ],
+      'primary key' => ['nid'],
+    ]);
   }
 }

--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -7,7 +7,19 @@ use Drupal\node\NodeInterface;
  * Implements hook_cron().
  */
 function filelink_usage_cron() {
-  \Drupal::service('filelink_usage.scanner')->scan();
+  $database = \Drupal::database();
+  $threshold = \Drupal::time()->getRequestTime() - 86400;
+  $query = $database->select('node_field_data', 'n');
+  $query->leftJoin('filelink_usage_scan_status', 's', 'n.nid = s.nid');
+  $query->fields('n', ['nid']);
+  $or = $query->orConditionGroup()
+    ->isNull('s.scanned')
+    ->condition('s.scanned', $threshold, '<');
+  $nids = $query->condition($or)->execute()->fetchCol();
+
+  if ($nids) {
+    \Drupal::service('filelink_usage.scanner')->scan($nids);
+  }
 }
 
 /**
@@ -87,11 +99,20 @@ function filelink_usage_rescan_node(NodeInterface $node) {
 }
 
 /**
+ * Mark a node as needing a rescan.
+ */
+function filelink_usage_mark_for_rescan(NodeInterface $node) {
+  \Drupal::database()->delete('filelink_usage_scan_status')
+    ->condition('nid', $node->id())
+    ->execute();
+}
+
+/**
  * Implements hook_entity_insert().
  */
 function filelink_usage_entity_insert(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
-    filelink_usage_rescan_node($entity);
+    filelink_usage_mark_for_rescan($entity);
   }
 }
 
@@ -100,7 +121,7 @@ function filelink_usage_entity_insert(EntityInterface $entity) {
  */
 function filelink_usage_entity_update(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
-    filelink_usage_rescan_node($entity);
+    filelink_usage_mark_for_rescan($entity);
   }
 }
 
@@ -136,6 +157,10 @@ function filelink_usage_entity_delete(EntityInterface $entity) {
     }
 
     $database->delete('filelink_usage_matches')
+      ->condition('nid', $entity->id())
+      ->execute();
+
+    $database->delete('filelink_usage_scan_status')
       ->condition('nid', $entity->id())
       ->execute();
   }

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -24,17 +24,47 @@ class FileLinkUsageScanner {
     $this->configFactory = $configFactory;
   }
 
-  public function scan(): array {
+  public function scan(?array $nids = NULL): array {
     $results = [];
     $verbose = (bool) $this->configFactory->get('filelink_usage.settings')->get('verbose_logging');
 
     $storage = $this->entityTypeManager->getStorage('node');
-    $nids = $storage->getQuery()
-      ->accessCheck(TRUE)
-      ->execute();
+    if ($nids === NULL) {
+      $nids = $storage->getQuery()
+        ->accessCheck(TRUE)
+        ->execute();
+    }
 
     $nodes = $storage->loadMultiple($nids);
     foreach ($nodes as $node) {
+      // Remove old usage records and matches so we can store a fresh set.
+      $links = $this->database->select('filelink_usage_matches', 'f')
+        ->fields('f', ['link'])
+        ->condition('nid', $node->id())
+        ->execute()
+        ->fetchCol();
+
+      foreach ($links as $link) {
+        $uri = $link;
+        if (preg_match('#https?://[^/]+(/sites/default/files/.*)#i', $uri, $m)) {
+          $uri = $m[1];
+        }
+        if (strpos($uri, '/sites/default/files/') === 0) {
+          $uri = 'public://' . substr($uri, strlen('/sites/default/files/'));
+        }
+
+        $file_storage = $this->entityTypeManager->getStorage('file');
+        $files = $file_storage->loadByProperties(['uri' => $uri]);
+        $file = $files ? reset($files) : NULL;
+        if ($file) {
+          $this->fileUsage->delete($file, 'filelink_usage', 'node', $node->id());
+        }
+      }
+
+      $this->database->delete('filelink_usage_matches')
+        ->condition('nid', $node->id())
+        ->execute();
+
       foreach ($node->getFields() as $field) {
         if ($field->getFieldDefinition()->getType() === 'text_long' || $field->getFieldDefinition()->getType() === 'text_with_summary') {
           $text = $field->value;
@@ -49,8 +79,8 @@ class FileLinkUsageScanner {
             }
 
             $file_storage = $this->entityTypeManager->getStorage('file');
-            $file = $file_storage->loadByProperties(['uri' => $uri]);
-            $file = $file ? reset($file) : NULL;
+            $files = $file_storage->loadByProperties(['uri' => $uri]);
+            $file = $files ? reset($files) : NULL;
 
             if ($file) {
               $usage = $this->fileUsage->listUsage($file);
@@ -83,6 +113,12 @@ class FileLinkUsageScanner {
           }
         }
       }
+
+      // Record successful scan time.
+      $this->database->merge('filelink_usage_scan_status')
+        ->key(['nid' => $node->id()])
+        ->fields(['scanned' => time()])
+        ->execute();
     }
 
     $this->logger->info('Scanned @count nodes for file links.', ['@count' => count($nodes)]);


### PR DESCRIPTION
## Summary
- track last scan time using `filelink_usage_scan_status`
- allow scanning a subset of nodes and record scan time
- mark nodes for rescan on create/update and clear data on delete
- cron scans only nodes without a recent scan

## Testing
- `php -l filelink_usage.install`
- `php -l filelink_usage.module`
- `php -l src/FileLinkUsageScanner.php`
- `apt-get update`
- `apt-get install -y php-cli`

------
https://chatgpt.com/codex/tasks/task_e_686c16faeb04833193602bcd1349cae1