### PR TITLE
Add cron scan frequency setting

### DIFF
--- a/config/install/filelink_usage.settings.yml
+++ b/config/install/filelink_usage.settings.yml
@@ -1,1 +1,3 @@
 verbose_logging: true
+scan_frequency: daily
+last_scan: 0

--- a/config/schema/filelink_usage.schema.yml
+++ b/config/schema/filelink_usage.schema.yml
@@ -5,3 +5,9 @@ filelink_usage.settings:
     verbose_logging:
       type: boolean
       label: 'Verbose logging'
+    scan_frequency:
+      type: string
+      label: 'Cron scan frequency'
+    last_scan:
+      type: integer
+      label: 'Timestamp of last cron scan'

--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -104,3 +104,17 @@ function filelink_usage_update_8002() {
     ]);
   }
 }
+
+/**
+ * Add scan frequency and last scan settings.
+ */
+function filelink_usage_update_8003() {
+  $config = \Drupal::configFactory()->getEditable('filelink_usage.settings');
+  if ($config->get('scan_frequency') === NULL) {
+    $config->set('scan_frequency', 'daily');
+  }
+  if ($config->get('last_scan') === NULL) {
+    $config->set('last_scan', 0);
+  }
+  $config->save();
+}

--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -7,8 +7,23 @@ use Drupal\node\NodeInterface;
  * Implements hook_cron().
  */
 function filelink_usage_cron() {
+  $config = \Drupal::configFactory()->getEditable('filelink_usage.settings');
+  $frequency = $config->get('scan_frequency');
+  $last_scan = (int) $config->get('last_scan');
+  $intervals = [
+    'hourly' => 3600,
+    'daily' => 86400,
+    'weekly' => 604800,
+  ];
+  $interval = $intervals[$frequency] ?? 86400;
+  $now = \Drupal::time()->getRequestTime();
+
+  if ($interval && $last_scan + $interval > $now) {
+    return;
+  }
+
   $database = \Drupal::database();
-  $threshold = \Drupal::time()->getRequestTime() - 86400;
+  $threshold = $now - 86400;
   $query = $database->select('node_field_data', 'n');
   $query->leftJoin('filelink_usage_scan_status', 's', 'n.nid = s.nid');
   $query->fields('n', ['nid']);
@@ -20,6 +35,8 @@ function filelink_usage_cron() {
   if ($nids) {
     \Drupal::service('filelink_usage.scanner')->scan($nids);
   }
+
+  $config->set('last_scan', $now)->save();
 }
 
 /**

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -38,6 +38,18 @@ class SettingsForm extends ConfigFormBase {
       '#description' => $this->t('Write detailed entries to the File Link Usage log channel.'),
     ];
 
+    $form['scan_frequency'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Cron scan frequency'),
+      '#options' => [
+        'hourly' => $this->t('Hourly'),
+        'daily' => $this->t('Daily'),
+        'weekly' => $this->t('Weekly'),
+      ],
+      '#default_value' => $config->get('scan_frequency'),
+      '#description' => $this->t('How often cron should scan for file links.'),
+    ];
+
     $form['actions']['purge'] = [
       '#type' => 'submit',
       '#value' => $this->t('Purge saved file links'),
@@ -56,6 +68,7 @@ class SettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->configFactory->getEditable('filelink_usage.settings')
       ->set('verbose_logging', $form_state->getValue('verbose_logging'))
+      ->set('scan_frequency', $form_state->getValue('scan_frequency'))
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
## Summary
- add `scan_frequency` and `last_scan` to module config
- expose new frequency option in `SettingsForm`
- track last cron scan timestamp
- run cron scans only when due based on frequency
- include update hook to set defaults for existing installs

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c195352dc833189cb1b143ab19e74