### PR TITLE
Fix Merge key compatibility with Drupal 11

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -102,7 +102,7 @@ function filelink_usage_rescan_node(NodeInterface $node) {
         }
 
         $database->merge('filelink_usage_matches')
-          ->key([
+          ->keys([
             'nid' => $node->id(),
             'link' => $match,
           ])

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -90,7 +90,7 @@ class FileLinkUsageScanner {
             }
 
             $this->database->merge('filelink_usage_matches')
-              ->key([
+              ->keys([
                 'nid' => $node->id(),
                 'link' => $match,
               ])
@@ -115,10 +115,10 @@ class FileLinkUsageScanner {
       }
 
       // Record successful scan time.
-      $this->database->merge('filelink_usage_scan_status')
-        ->key(['nid' => $node->id()])
-        ->fields(['scanned' => time()])
-        ->execute();
+        $this->database->merge('filelink_usage_scan_status')
+          ->key('nid', $node->id())
+          ->fields(['scanned' => time()])
+          ->execute();
     }
 
     $this->logger->info('Scanned @count nodes for file links.', ['@count' => count($nodes)]);


### PR DESCRIPTION
## Summary
- use `keys()` for multi-field merges and `key()` for single field

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1f68f18c833194a0e42d5cacfb79