### PR TITLE
Respect cron scan interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,18 @@ The `filelink_usage` module scans all text fields across your Drupal 10 or 11 si
 - 🔍 Scans `text_long` and `text_with_summary` fields for links to files
 - 🧠 Detects links in absolute (`https://yoursite.com/sites/default/files/...`) or relative (`/sites/default/files/...`) format
 - 🗃️ Updates `file_usage` records so referenced files are preserved
-- ⏱️ Automatically scans during Drupal cron runs
+- ⏱️ Automatically scans during Drupal cron runs respecting the configured scan frequency
 - 💾 Save hooks keep file usage in sync on node create, update, and delete
 - 💻 `drush filelink_usage:scan` command to run the scanner manually
 - ⚙️ Configuration form with verbose logging enabled by default
 - 🧹 Admin UI button to purge stored file link matches
+- 📅 Nodes are re-scanned if their last scan time exceeds the chosen interval
+
+## Configuration
+
+Set the **Cron scan frequency** (hourly, daily, or weekly) on the module's
+settings page. This value determines how often cron runs the scanner and how
+long a node can go before it is rescanned.
 
 ## Use Cases
 

--- a/config/schema/filelink_usage.schema.yml
+++ b/config/schema/filelink_usage.schema.yml
@@ -8,6 +8,10 @@ filelink_usage.settings:
     scan_frequency:
       type: string
       label: 'Cron scan frequency'
+      allowed_values:
+        - hourly
+        - daily
+        - weekly
     last_scan:
       type: integer
       label: 'Timestamp of last cron scan'

--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -23,7 +23,8 @@ function filelink_usage_cron() {
   }
 
   $database = \Drupal::database();
-  $threshold = $now - 86400;
+  // Rescan nodes that haven't been scanned within the configured interval.
+  $threshold = $interval ? $now - $interval : 0;
   $query = $database->select('node_field_data', 'n');
   $query->leftJoin('filelink_usage_scan_status', 's', 'n.nid = s.nid');
   $query->fields('n', ['nid']);


### PR DESCRIPTION
## Summary
- compute rescan threshold based on configured scan frequency instead of a fixed 24h
- document cron scan frequency in README
- restrict `scan_frequency` config values in the schema

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c24a111548331b7e44834e7fd38e4