### PR TITLE
Refactor cron to injectable service

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -7,46 +7,14 @@ use Drupal\node\NodeInterface;
  * Implements hook_cron().
  */
 function filelink_usage_cron() {
-  $config = \Drupal::configFactory()->getEditable('filelink_usage.settings');
-  $frequency = $config->get('scan_frequency');
-  $last_scan = (int) $config->get('last_scan');
-  $intervals = [
-    'hourly' => 3600,
-    'daily' => 86400,
-    'weekly' => 604800,
-  ];
-  $interval = $intervals[$frequency] ?? 86400;
-  $now = \Drupal::time()->getRequestTime();
-
-  if ($interval && $last_scan + $interval > $now) {
-    return;
-  }
-
-  $database = \Drupal::database();
-  // Rescan nodes that haven't been scanned within the configured interval.
-  $threshold = $interval ? $now - $interval : 0;
-  $query = $database->select('node_field_data', 'n');
-  $query->leftJoin('filelink_usage_scan_status', 's', 'n.nid = s.nid');
-  $query->fields('n', ['nid']);
-  $or = $query->orConditionGroup()
-    ->isNull('s.scanned')
-    ->condition('s.scanned', $threshold, '<');
-  $nids = $query->condition($or)->execute()->fetchCol();
-
-  if ($nids) {
-    \Drupal::service('filelink_usage.scanner')->scan($nids);
-  }
-
-  $config->set('last_scan', $now)->save();
+  \Drupal::service('filelink_usage.manager')->runCron();
 }
 
 /**
  * Mark a node as needing a rescan.
  */
 function filelink_usage_mark_for_rescan(NodeInterface $node) {
-  \Drupal::database()->delete('filelink_usage_scan_status')
-    ->condition('nid', $node->id())
-    ->execute();
+  \Drupal::service('filelink_usage.manager')->markForRescan($node);
 }
 
 /**
@@ -54,7 +22,7 @@ function filelink_usage_mark_for_rescan(NodeInterface $node) {
  */
 function filelink_usage_entity_insert(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
-    filelink_usage_mark_for_rescan($entity);
+    \Drupal::service('filelink_usage.manager')->markForRescan($entity);
   }
 }
 
@@ -63,7 +31,7 @@ function filelink_usage_entity_insert(EntityInterface $entity) {
  */
 function filelink_usage_entity_update(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
-    filelink_usage_mark_for_rescan($entity);
+    \Drupal::service('filelink_usage.manager')->markForRescan($entity);
   }
 }
 
@@ -72,38 +40,6 @@ function filelink_usage_entity_update(EntityInterface $entity) {
  */
 function filelink_usage_entity_delete(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
-    $database = \Drupal::database();
-    $file_usage = \Drupal::service('file.usage');
-    $entity_type_manager = \Drupal::entityTypeManager();
-
-    $links = $database->select('filelink_usage_matches', 'f')
-      ->fields('f', ['link'])
-      ->condition('nid', $entity->id())
-      ->execute()
-      ->fetchCol();
-
-    foreach ($links as $link) {
-      $uri = $link;
-      if (preg_match('#https?://[^/]+(/sites/default/files/.*)#i', $uri, $m)) {
-        $uri = $m[1];
-      }
-      if (strpos($uri, '/sites/default/files/') === 0) {
-        $uri = 'public://' . substr($uri, strlen('/sites/default/files/'));
-      }
-      $file_storage = $entity_type_manager->getStorage('file');
-      $files = $file_storage->loadByProperties(['uri' => $uri]);
-      $file = $files ? reset($files) : NULL;
-      if ($file) {
-        $file_usage->delete($file, 'filelink_usage', 'node', $entity->id());
-      }
-    }
-
-    $database->delete('filelink_usage_matches')
-      ->condition('nid', $entity->id())
-      ->execute();
-
-    $database->delete('filelink_usage_scan_status')
-      ->condition('nid', $entity->id())
-      ->execute();
+    \Drupal::service('filelink_usage.manager')->cleanupNode($entity);
   }
 }

--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -5,6 +5,10 @@ services:
     tags:
       - { name: default }
 
+  filelink_usage.manager:
+    class: Drupal\filelink_usage\FileLinkUsageManager
+    arguments: ['@database', '@config.factory', '@time', '@filelink_usage.scanner', '@file.usage', '@entity_type.manager']
+
   logger.channel.filelink_usage:
     class: Drupal\Core\Logger\LoggerChannel
     factory: 'logger.factory:get'

--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\filelink_usage;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\file\FileUsage\FileUsageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+
+class FileLinkUsageManager {
+
+  protected Connection $database;
+  protected ConfigFactoryInterface $configFactory;
+  protected TimeInterface $time;
+  protected FileLinkUsageScanner $scanner;
+  protected FileUsageInterface $fileUsage;
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  public function __construct(Connection $database, ConfigFactoryInterface $configFactory, TimeInterface $time, FileLinkUsageScanner $scanner, FileUsageInterface $fileUsage, EntityTypeManagerInterface $entityTypeManager) {
+    $this->database = $database;
+    $this->configFactory = $configFactory;
+    $this->time = $time;
+    $this->scanner = $scanner;
+    $this->fileUsage = $fileUsage;
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * Execute cron scanning based on configured frequency.
+   */
+  public function runCron(): void {
+    $config = $this->configFactory->getEditable('filelink_usage.settings');
+    $frequency = $config->get('scan_frequency');
+    $last_scan = (int) $config->get('last_scan');
+    $intervals = [
+      'hourly' => 3600,
+      'daily' => 86400,
+      'weekly' => 604800,
+    ];
+    $interval = $intervals[$frequency] ?? 86400;
+    $now = $this->time->getRequestTime();
+
+    if ($interval && $last_scan + $interval > $now) {
+      return;
+    }
+
+    $threshold = $interval ? $now - $interval : 0;
+    $query = $this->database->select('node_field_data', 'n');
+    $query->leftJoin('filelink_usage_scan_status', 's', 'n.nid = s.nid');
+    $query->fields('n', ['nid']);
+    $or = $query->orConditionGroup()
+      ->isNull('s.scanned')
+      ->condition('s.scanned', $threshold, '<');
+    $nids = $query->condition($or)->execute()->fetchCol();
+
+    if ($nids) {
+      $this->scanner->scan($nids);
+    }
+
+    $config->set('last_scan', $now)->save();
+  }
+
+  /**
+   * Mark a node for rescan by clearing its status.
+   */
+  public function markForRescan(NodeInterface $node): void {
+    $this->database->delete('filelink_usage_scan_status')
+      ->condition('nid', $node->id())
+      ->execute();
+  }
+
+  /**
+   * Cleanup file usage when a node is deleted.
+   */
+  public function cleanupNode(NodeInterface $node): void {
+    $links = $this->database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('nid', $node->id())
+      ->execute()
+      ->fetchCol();
+
+    foreach ($links as $link) {
+      $uri = $link;
+      if (preg_match('#https?://[^/]+(/sites/default/files/.*)#i', $uri, $m)) {
+        $uri = $m[1];
+      }
+      if (strpos($uri, '/sites/default/files/') === 0) {
+        $uri = 'public://' . substr($uri, strlen('/sites/default/files/'));
+      }
+      $file_storage = $this->entityTypeManager->getStorage('file');
+      $files = $file_storage->loadByProperties(['uri' => $uri]);
+      $file = $files ? reset($files) : NULL;
+      if ($file) {
+        $this->fileUsage->delete($file, 'filelink_usage', 'node', $node->id());
+      }
+    }
+
+    $this->database->delete('filelink_usage_matches')
+      ->condition('nid', $node->id())
+      ->execute();
+
+    $this->database->delete('filelink_usage_scan_status')
+      ->condition('nid', $node->id())
+      ->execute();
+  }
+
+}


### PR DESCRIPTION
## Summary
- add `FileLinkUsageManager` service to own cron duties
- register the new service in `filelink_usage.services.yml`
- delegate all procedural hooks to the manager instead of using \Drupal service lookups

## Testing
- `drush filelink_usage:scan` *(fails: drush not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1e30b4648331a7a6056c668f8e5a