### PR TITLE
Add dedicated cron service

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -7,7 +7,7 @@ use Drupal\node\NodeInterface;
  * Implements hook_cron().
  */
 function filelink_usage_cron() {
-  \Drupal::service('filelink_usage.manager')->runCron();
+  \Drupal::service('filelink_usage.cron')->run();
 }
 
 /**

--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -9,6 +9,10 @@ services:
     class: Drupal\filelink_usage\FileLinkUsageManager
     arguments: ['@database', '@config.factory', '@time', '@filelink_usage.scanner', '@file.usage', '@entity_type.manager']
 
+  filelink_usage.cron:
+    class: Drupal\filelink_usage\FileLinkUsageCron
+    arguments: ['@filelink_usage.manager']
+
   logger.channel.filelink_usage:
     class: Drupal\Core\Logger\LoggerChannel
     factory: 'logger.factory:get'

--- a/src/FileLinkUsageCron.php
+++ b/src/FileLinkUsageCron.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\filelink_usage;
+
+/**
+ * Service that triggers cron-based scanning of nodes.
+ */
+class FileLinkUsageCron {
+
+  /**
+   * The manager handling scanning logic.
+   */
+  protected FileLinkUsageManager $manager;
+
+  /**
+   * Constructs the cron service.
+   */
+  public function __construct(FileLinkUsageManager $manager) {
+    $this->manager = $manager;
+  }
+
+  /**
+   * Execute the cron scan.
+   */
+  public function run(): void {
+    $this->manager->runCron();
+  }
+
+}


### PR DESCRIPTION
## Summary
- add FileLinkUsageCron service
- register the cron service
- delegate `hook_cron` to the new service

## Testing
- `drush filelink_usage:scan` *(fails: drush not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c262996788331a5ff4eacc83ebd1a