### PR TITLE
Fix service dependency for time

### DIFF
--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -7,7 +7,7 @@ services:
 
   filelink_usage.manager:
     class: Drupal\filelink_usage\FileLinkUsageManager
-    arguments: ['@database', '@config.factory', '@time', '@filelink_usage.scanner', '@file.usage', '@entity_type.manager']
+    arguments: ['@database', '@config.factory', '@datetime.time', '@filelink_usage.scanner', '@file.usage', '@entity_type.manager']
 
   logger.channel.filelink_usage:
     class: Drupal\Core\Logger\LoggerChannel


### PR DESCRIPTION
## Summary
- use Drupal's `datetime.time` service instead of the missing `time` service

## Testing
- `find . -name '*.php' -print | xargs -I {} php -l {}` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c289355048331a365a15731fe5055