### PR TITLE
Add 'every' cron frequency option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `filelink_usage` module scans all text fields across your Drupal 10 or 11 si
 
 ## Configuration
 
-Set the **Cron scan frequency** (hourly, daily, or weekly) on the module's
+Set the **Cron scan frequency** (hourly, daily, weekly, or every cron run) on the module's
 settings page. This value determines how often cron runs the scanner and how
 long a node can go before it is rescanned.
 

--- a/config/schema/filelink_usage.schema.yml
+++ b/config/schema/filelink_usage.schema.yml
@@ -9,6 +9,7 @@ filelink_usage.settings:
       type: string
       label: 'Cron scan frequency'
       allowed_values:
+        - every
         - hourly
         - daily
         - weekly

--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -35,6 +35,7 @@ class FileLinkUsageManager {
     $frequency = $config->get('scan_frequency');
     $last_scan = (int) $config->get('last_scan');
     $intervals = [
+      'every' => 0,
       'hourly' => 3600,
       'daily' => 86400,
       'weekly' => 604800,
@@ -46,7 +47,7 @@ class FileLinkUsageManager {
       return;
     }
 
-    $threshold = $interval ? $now - $interval : 0;
+    $threshold = $interval ? $now - $interval : $now;
     $query = $this->database->select('node_field_data', 'n');
     $query->leftJoin('filelink_usage_scan_status', 's', 'n.nid = s.nid');
     $query->fields('n', ['nid']);

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -42,6 +42,7 @@ class SettingsForm extends ConfigFormBase {
       '#type' => 'select',
       '#title' => $this->t('Cron scan frequency'),
       '#options' => [
+        'every' => $this->t('Every cron run'),
         'hourly' => $this->t('Hourly'),
         'daily' => $this->t('Daily'),
         'weekly' => $this->t('Weekly'),


### PR DESCRIPTION
## Summary
- add 'every' cron frequency option to config schema and settings form
- support the new option in cron manager
- document the option in the README

## Testing
- `php -l src/Form/SettingsForm.php`
- `php -l src/FileLinkUsageManager.php`


------
https://chatgpt.com/codex/tasks/task_e_686c2c691c1c8331a006d5c5ad2e3803