### PR TITLE
Fix duplicate file usage entries

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -85,7 +85,20 @@ class FileLinkUsageScanner {
 
             if ($file) {
               $usage = $this->fileUsage->listUsage($file);
-              if (empty($usage['filelink_usage']['node'][$node->id()])) {
+
+              // Check if any module already recorded usage for this node.
+              $usage_exists = FALSE;
+              foreach ($usage as $module_name => $module_usage) {
+                if (!empty($module_usage['node'][$node->id()])) {
+                  // Remove entries from other modules to avoid duplicate rows.
+                  if ($module_name !== 'filelink_usage') {
+                    $this->fileUsage->delete($file, $module_name, 'node', $node->id());
+                  }
+                  $usage_exists = TRUE;
+                }
+              }
+
+              if (!$usage_exists) {
                 $this->fileUsage->add($file, 'filelink_usage', 'node', $node->id());
               }
             }


### PR DESCRIPTION
## Summary
- prevent multiple file usage rows from different modules

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c315145c08331b660dfb403f740e4