### PR TITLE
Scan node on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `filelink_usage` module scans all text fields across your Drupal 10 or 11 si
 - 🧠 Detects links in absolute (`https://yoursite.com/sites/default/files/...`) or relative (`/sites/default/files/...`) format
 - 🗃️ Updates `file_usage` records so referenced files are preserved
 - ⏱️ Automatically scans during Drupal cron runs respecting the configured scan frequency
-- 💾 Save hooks keep file usage in sync on node create, update, and delete
+- 💾 Nodes are scanned immediately on save to keep file usage in sync
 - 💻 `drush filelink_usage:scan` command to run the scanner manually
 - ⚙️ Configuration form with verbose logging enabled by default
 - 🧹 Admin UI button to purge stored file link matches

--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -22,7 +22,7 @@ function filelink_usage_mark_for_rescan(NodeInterface $node) {
  */
 function filelink_usage_entity_insert(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
-    \Drupal::service('filelink_usage.manager')->markForRescan($entity);
+    \Drupal::service('filelink_usage.scanner')->scanNode($entity);
   }
 }
 
@@ -31,7 +31,7 @@ function filelink_usage_entity_insert(EntityInterface $entity) {
  */
 function filelink_usage_entity_update(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
-    \Drupal::service('filelink_usage.manager')->markForRescan($entity);
+    \Drupal::service('filelink_usage.scanner')->scanNode($entity);
   }
 }
 


### PR DESCRIPTION
## Summary
- scan nodes immediately when inserted or updated
- document that saves trigger immediate scanning

## Testing
- `drush filelink_usage:scan` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c35e8a254833184ceddc9c67c71d8