### PR TITLE
Invalidate Drupal file cache on usage updates

### DIFF
--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -4,6 +4,7 @@ namespace Drupal\filelink_usage;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Cache\Cache;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\file\FileUsage\FileUsageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -95,6 +96,7 @@ class FileLinkUsageManager {
       $file = $files ? reset($files) : NULL;
       if ($file) {
         $this->fileUsage->delete($file, 'filelink_usage', 'node', $node->id());
+        Cache::invalidateTags(['file:' . $file->id()]);
       }
     }
 

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -4,6 +4,7 @@ namespace Drupal\filelink_usage;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Cache\Cache;
 use Drupal\file\FileUsage\FileUsageInterface;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
@@ -60,6 +61,7 @@ class FileLinkUsageScanner {
         $file = $files ? reset($files) : NULL;
         if ($file) {
           $this->fileUsage->delete($file, 'filelink_usage', 'node', $node->id());
+          Cache::invalidateTags(['file:' . $file->id()]);
         }
       }
 
@@ -94,6 +96,7 @@ class FileLinkUsageScanner {
                   // Remove entries from other modules to avoid duplicate rows.
                   if ($module_name !== 'filelink_usage') {
                     $this->fileUsage->delete($file, $module_name, 'node', $node->id());
+                    Cache::invalidateTags(['file:' . $file->id()]);
                   }
                   $usage_exists = TRUE;
                 }
@@ -101,6 +104,7 @@ class FileLinkUsageScanner {
 
               if (!$usage_exists) {
                 $this->fileUsage->add($file, 'filelink_usage', 'node', $node->id());
+                Cache::invalidateTags(['file:' . $file->id()]);
               }
             }
 


### PR DESCRIPTION
## Summary
- notify Drupal's cache system whenever file usages are added or deleted
- purge file cache after node cleanup

## Testing
- `php -l src/FileLinkUsageScanner.php`
- `php -l src/FileLinkUsageManager.php`
- `phpunit -c phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3de3d1e4833189cff0b8245d72d3