### PR TITLE
Add link normalizer service

### DIFF
--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -137,3 +137,34 @@ function filelink_usage_update_8003() {
   }
   $config->save();
 }
+
+/**
+ * Normalize existing link records.
+ */
+function filelink_usage_update_8004() {
+  $connection = \Drupal::database();
+  /** @var \Drupal\filelink_usage\FileLinkUsageNormalizer $normalizer */
+  $normalizer = \Drupal::service('filelink_usage.normalizer');
+
+  $query = $connection->select('filelink_usage_matches', 'f')
+    ->fields('f', ['id', 'nid', 'link'])
+    ->orderBy('id', 'ASC');
+  $seen = [];
+  foreach ($query->execute() as $row) {
+    $normalized = $normalizer->normalize($row->link);
+    $key = $row->nid . '|' . $normalized;
+    if (isset($seen[$key])) {
+      $connection->delete('filelink_usage_matches')
+        ->condition('id', $row->id)
+        ->execute();
+      continue;
+    }
+    $seen[$key] = TRUE;
+    if ($normalized !== $row->link) {
+      $connection->update('filelink_usage_matches')
+        ->fields(['link' => $normalized])
+        ->condition('id', $row->id)
+        ->execute();
+    }
+  }
+}

--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -1,13 +1,16 @@
 services:
+  filelink_usage.normalizer:
+    class: Drupal\filelink_usage\FileLinkUsageNormalizer
+
   filelink_usage.scanner:
     class: Drupal\filelink_usage\FileLinkUsageScanner
-    arguments: ['@entity_type.manager', '@database', '@file.usage', '@logger.channel.filelink_usage', '@config.factory']
+    arguments: ['@entity_type.manager', '@database', '@file.usage', '@logger.channel.filelink_usage', '@config.factory', '@filelink_usage.normalizer']
     tags:
       - { name: default }
 
   filelink_usage.manager:
     class: Drupal\filelink_usage\FileLinkUsageManager
-    arguments: ['@database', '@config.factory', '@datetime.time', '@filelink_usage.scanner', '@file.usage', '@entity_type.manager']
+    arguments: ['@database', '@config.factory', '@datetime.time', '@filelink_usage.scanner', '@file.usage', '@entity_type.manager', '@filelink_usage.normalizer']
 
   filelink_usage.cron:
     class: Drupal\filelink_usage\FileLinkUsageCron

--- a/src/FileLinkUsageNormalizer.php
+++ b/src/FileLinkUsageNormalizer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\filelink_usage;
+
+use Drupal\Component\Utility\Html;
+
+class FileLinkUsageNormalizer {
+
+  public function normalize(string $link): string {
+    // Decode HTML entities and trim common surrounding characters.
+    $link = Html::decodeEntities($link);
+    $link = trim($link, " \t\n\r\0\x0B\"'");
+
+    // Strip hostnames from absolute URLs.
+    if (preg_match('#^https?://[^/]+(/.*)$#i', $link, $m)) {
+      $link = $m[1];
+    }
+
+    // Collapse repeated slashes.
+    $link = preg_replace('#/{2,}#', '/', $link);
+
+    // Remove query strings and fragments.
+    $link = preg_replace('/[\?#].*$/', '', $link);
+    $link = rtrim($link, '/');
+
+    // Convert sites/default/files paths to public scheme.
+    if (strpos($link, '/sites/default/files/') === 0) {
+      $link = 'public://' . substr($link, strlen('/sites/default/files/'));
+    }
+
+    return $link;
+  }
+
+}

--- a/tests/src/Functional/FileLinkUsageScannerTest.php
+++ b/tests/src/Functional/FileLinkUsageScannerTest.php
@@ -79,4 +79,44 @@ class FileLinkUsageScannerTest extends KernelTestBase {
     $this->assertArrayHasKey($node->id(), $usage['filelink_usage']['node']);
   }
 
+  /**
+   * Tests link normalization handles hostnames, slashes and query strings.
+   */
+  public function testLinkNormalization(): void {
+    $uri = 'public://example.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'example');
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'example.txt',
+    ]);
+    $file->save();
+
+    $body = implode(' ', [
+      '<a href="https://example.com/sites/default/files//example.txt?foo=1">L1</a>',
+      '<a href="/sites/default/files/example.txt">L2</a>'
+    ]);
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Test node',
+      'body' => [
+        'value' => $body,
+        'format' => 'plain_text',
+      ],
+    ]);
+    $node->save();
+
+    $this->container->get('filelink_usage.scanner')->scan([$node->id()]);
+
+    $link = $this->container->get('database')->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('nid', $node->id())
+      ->execute()
+      ->fetchField();
+
+    $this->assertEquals('public://example.txt', $link);
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertCount(1, $usage['filelink_usage']['node']);
+  }
+
 }
+


### PR DESCRIPTION
## Summary
- introduce `FileLinkUsageNormalizer` for cleaning links
- inject the normalizer into scanner and manager
- update service wiring and add update hook to normalize existing records
- normalize links while scanning and cleaning up
- simplify addUsageForFile query
- expand functional tests for link normalization

## Testing
- `composer validate --no-check-all --strict` *(fails: command not found)*
- `php -l src/FileLinkUsageNormalizer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc6ea15ac8331b1edccf9b49d4c4c