### PR TITLE
Inject time interface into scanner

### DIFF
--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -4,7 +4,7 @@ services:
 
   filelink_usage.scanner:
     class: Drupal\filelink_usage\FileLinkUsageScanner
-    arguments: ['@entity_type.manager', '@database', '@file.usage', '@logger.channel.filelink_usage', '@config.factory', '@filelink_usage.normalizer']
+    arguments: ['@entity_type.manager', '@database', '@file.usage', '@logger.channel.filelink_usage', '@config.factory', '@filelink_usage.normalizer', '@datetime.time']
     tags:
       - { name: default }
 


### PR DESCRIPTION
## Summary
- reuse normalizer when loading existing file link matches
- inject `TimeInterface` into `FileLinkUsageScanner`
- use `$this->time->getRequestTime()` when writing timestamps
- update service wiring for the scanner

## Testing
- `phpunit tests/src/Functional/FileLinkUsageScannerTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc86a68788331b14174552a6ed74b