### PR TITLE
Add purge of scan status

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -79,7 +79,14 @@ class SettingsForm extends ConfigFormBase {
    * Purges saved file link matches from the database.
    */
   public function purgeFileLinkMatches(array &$form, FormStateInterface $form_state) {
-    Drupal::database()->truncate('filelink_usage_matches')->execute();
+    $connection = Drupal::database();
+    $connection->truncate('filelink_usage_matches')->execute();
+    $connection->truncate('filelink_usage_scan_status')->execute();
+
+    $this->configFactory->getEditable('filelink_usage.settings')
+      ->set('last_scan', 0)
+      ->save();
+
     $this->messenger()->addMessage($this->t('All saved file links have been purged.'));
     $form_state->setRebuild();
   }

--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Core\Form\FormState;
+use Drupal\filelink_usage\Form\SettingsForm;
+
+/**
+ * Tests purging saved file links and forcing a rescan via cron.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsagePurgeTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'filelink_usage',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('node');
+    $this->installSchema('file', ['file_usage']);
+    $this->installConfig(['node', 'filter']);
+
+    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+  }
+
+  /**
+   * Ensures purge removes data and cron performs a full rescan.
+   */
+  public function testPurgeAndCronRescan(): void {
+    $uri = 'public://example.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'example');
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'example.txt',
+    ]);
+    $file->save();
+
+    $body = '<a href="/sites/default/files/example.txt">Download</a>';
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Test node',
+      'body' => [
+        'value' => $body,
+        'format' => 'plain_text',
+      ],
+    ]);
+    $node->save();
+
+    // Initial scan to populate tables.
+    $this->container->get('filelink_usage.scanner')->scan([$node->id()]);
+
+    $database = $this->container->get('database');
+    $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();
+    $this->assertGreaterThan(0, $count);
+    $count = $database->select('filelink_usage_scan_status')->countQuery()->execute()->fetchField();
+    $this->assertGreaterThan(0, $count);
+
+    // Call the purge handler.
+    $form = SettingsForm::create($this->container);
+    $form_state = new FormState();
+    $form->purgeFileLinkMatches([], $form_state);
+
+    $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();
+    $this->assertEquals(0, $count);
+    $count = $database->select('filelink_usage_scan_status')->countQuery()->execute()->fetchField();
+    $this->assertEquals(0, $count);
+    $this->assertEquals(0, $this->config('filelink_usage.settings')->get('last_scan'));
+
+    // Run cron which should rescan the node.
+    $this->container->get('filelink_usage.manager')->runCron();
+    $count = $database->select('filelink_usage_scan_status')->countQuery()->execute()->fetchField();
+    $this->assertGreaterThan(0, $count);
+    $this->assertGreaterThan(0, $this->config('filelink_usage.settings')->get('last_scan'));
+  }
+
+}


### PR DESCRIPTION
## Summary
- purge scan status table and reset last scan
- create kernel test to verify purge resets tables and forces cron rescan

## Testing
- `phpunit -c phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd82ddd388331a8733d4a043c4de1