### PR TITLE
Add rescan marking in purge action

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -83,6 +83,16 @@ class SettingsForm extends ConfigFormBase {
     $connection->truncate('filelink_usage_matches')->execute();
     $connection->truncate('filelink_usage_scan_status')->execute();
 
+    // Mark all nodes for rescan in case additional modules rely on this hook.
+    $storage = Drupal::entityTypeManager()->getStorage('node');
+    $nids = $storage->getQuery()->accessCheck(FALSE)->execute();
+    if ($nids) {
+      $nodes = $storage->loadMultiple($nids);
+      foreach ($nodes as $node) {
+        filelink_usage_mark_for_rescan($node);
+      }
+    }
+
     $this->configFactory->getEditable('filelink_usage.settings')
       ->set('last_scan', 0)
       ->save();


### PR DESCRIPTION
## Summary
- mark every node for rescan after purging stored matches

## Testing
- `php -l src/Form/SettingsForm.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cdd3d778083319315559912464b63