### PR TITLE
Use count query for rescan check

### DIFF
--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -48,11 +48,11 @@ class FileLinkUsageManager {
     $interval = $intervals[$frequency] ?? 86400;
     $now = $this->time->getRequestTime();
 
-    $matches_exist = (bool) $this->database->select('filelink_usage_matches')
-      ->range(0, 1)
+    $match_count = (int) $this->database->select('filelink_usage_matches')
+      ->countQuery()
       ->execute()
       ->fetchField();
-    $force_rescan = !$matches_exist;
+    $force_rescan = $match_count === 0;
 
     if (!$force_rescan && $interval && $last_scan + $interval > $now) {
       return;


### PR DESCRIPTION
## Summary
- check `filelink_usage_matches` row count in `runCron()`
- queue a full rescan when there are no matches

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cdeada71c8331a33a9446c6889672