### PR TITLE
Allow spaces and encoded links in FileLinkUsageScanner

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -73,7 +73,7 @@ class FileLinkUsageScanner {
       foreach ($node->getFields() as $field) {
         if ($field->getFieldDefinition()->getType() === 'text_long' || $field->getFieldDefinition()->getType() === 'text_with_summary') {
           $text = $field->value;
-          preg_match_all('/(public:\/\/[^\s"\']+|\/sites\/default\/files\/[^\s"\']+|https?:\/\/[^\/"]+\/sites\/default\/files\/[^\s"\']+)/i', $text, $matches);
+          preg_match_all('/(public:\/\/[^"\']+|\/sites\/default\/files\/[^"\']+|https?:\/\/[^\/"]+\/sites\/default\/files\/[^"\']+)/i', $text, $matches);
           foreach ($matches[0] as $match) {
             $uri = $this->normalizer->normalize($match);
 


### PR DESCRIPTION
## Summary
- loosen scanner regex to match spaces and percent-encoded characters
- cover new paths like `My%20File.pdf` and `my file.txt`

## Testing
- `phpunit tests/src/Kernel` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce068603c8331956193d54d644920