### PR TITLE
Clear rescan status when purging links

### DIFF
--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -92,6 +92,13 @@ class FileLinkUsageManager {
   }
 
   /**
+   * Clear scan status for all nodes.
+   */
+  public function markAllForRescan(): void {
+    $this->database->truncate('filelink_usage_scan_status')->execute();
+  }
+
+  /**
    * Cleanup file usage when a node is deleted.
    */
   public function cleanupNode(NodeInterface $node): void {

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -81,7 +81,7 @@ class SettingsForm extends ConfigFormBase {
   public function purgeFileLinkMatches(array &$form, FormStateInterface $form_state) {
     $connection = Drupal::database();
     $connection->truncate('filelink_usage_matches')->execute();
-    $connection->truncate('filelink_usage_scan_status')->execute();
+    \Drupal::service('filelink_usage.manager')->markAllForRescan();
 
     // Mark all nodes for rescan in case additional modules rely on this hook.
     $storage = Drupal::entityTypeManager()->getStorage('node');


### PR DESCRIPTION
## Summary
- add a manager method to reset scan status for all nodes
- call the new method from the purge action

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce35e766c8331afa266d949ffa643