### PR TITLE
Fix syntax error in FileLinkUsageScanner

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -160,4 +160,4 @@ class FileLinkUsageScanner {
   }
 
 }
-
+}


### PR DESCRIPTION
## Summary
- add missing closing brace for the `FileLinkUsageScanner` class

## Testing
- `grep -o '}' src/FileLinkUsageScanner.php | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_686cf233fea88331a8c3c9ad3608764a