### PR TITLE
Fix unmatched braces in FileLinkUsageScanner

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -152,6 +152,8 @@ class FileLinkUsageScanner {
     return $results;
   }
 
+  }
+
   /**
    * Scan a single node for file links and update usage.
    */
@@ -159,5 +161,4 @@ class FileLinkUsageScanner {
     return $this->scan([$node->id()]);
   }
 
-}
 }


### PR DESCRIPTION
## Summary
- close the `scan` method properly so `cron` can run

## Testing
- `find . -name '*.php' -print | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_686d09c7cd4483319f7c2de3cc4833c1