### PR TITLE
Add verbose scan progress logging

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -44,6 +44,7 @@ class FileLinkUsageScanner {
     }
 
     $nodes = $storage->loadMultiple($nids);
+    $count = 0;
     foreach ($nodes as $node) {
       // Retrieve existing matches so we know which links are new.
       $links = $this->database->select('filelink_usage_matches', 'f')
@@ -146,6 +147,13 @@ class FileLinkUsageScanner {
           ->key('nid', $node->id())
           ->fields(['scanned' => $this->time->getRequestTime()])
           ->execute();
+
+      $count++;
+      if ($verbose && $count % 100 === 0) {
+        $this->logger->info('Scanned @count nodes for file links so far.', [
+          '@count' => $count,
+        ]);
+      }
     }
 
     $nids_list = implode(', ', array_keys($nodes));


### PR DESCRIPTION
## Summary
- track count of scanned nodes in FileLinkUsageScanner
- log progress every 100 nodes when verbose logging is enabled

## Testing
- `phpunit --version` *(fails: command not found)*
- `composer install --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3b1abf3c8331a71093e33ec7f995