### PR TITLE
Show count of hard-coded links on settings form

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -31,6 +31,21 @@ class SettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('filelink_usage.settings');
 
+    $count = \Drupal::database()
+      ->select('filelink_usage_matches')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+
+    $form['match_count'] = [
+      '#type' => 'markup',
+      '#markup' => $this->t('Detected hard-coded links: @count', ['@count' => $count]),
+      '#weight' => -100,
+      '#cache' => [
+        'max-age' => 0,
+      ],
+    ];
+
     $form['verbose_logging'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Verbose logging'),


### PR DESCRIPTION
## Summary
- query the `filelink_usage_matches` table in `SettingsForm`
- display "Detected hard-coded links" markup

## Testing
- `php -l src/Form/SettingsForm.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3c88bd90833195f79e5116757ff2