### PR TITLE
Update defaults and cron frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ The `filelink_usage` module scans all text fields across your Drupal 10 or 11 si
 - 📥 Newly uploaded files automatically gain usage entries when referenced
   in existing content
 - 💻 `drush filelink_usage:scan` command to run the scanner manually
-- ⚙️ Configuration form with verbose logging enabled by default
+- ⚙️ Configuration form with verbose logging disabled by default
 - 🧹 Admin UI button to purge stored file link matches
 - 📅 Nodes are re-scanned if their last scan time exceeds the chosen interval
 
 ## Configuration
 
-Set the **Cron scan frequency** (hourly, daily, weekly, or every cron run) on the module's
+Set the **Cron scan frequency** (hourly, daily, weekly, monthly, yearly, or every cron run) on the module's
 settings page. This value determines how often cron runs the scanner and how
-long a node can go before it is rescanned.
+long a node can go before it is rescanned. The default frequency is **yearly**.
 
 ## Purging Saved Links and Cron Behavior
 

--- a/config/install/filelink_usage.settings.yml
+++ b/config/install/filelink_usage.settings.yml
@@ -1,3 +1,3 @@
-verbose_logging: true
-scan_frequency: daily
+verbose_logging: false
+scan_frequency: yearly
 last_scan: 0

--- a/config/schema/filelink_usage.schema.yml
+++ b/config/schema/filelink_usage.schema.yml
@@ -13,6 +13,8 @@ filelink_usage.settings:
         - hourly
         - daily
         - weekly
+        - monthly
+        - yearly
     last_scan:
       type: integer
       label: 'Timestamp of last cron scan'

--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -168,3 +168,20 @@ function filelink_usage_update_8004() {
     }
   }
 }
+
+/**
+ * Update default settings for verbose logging and scan frequency.
+ */
+function filelink_usage_update_8005() {
+  $config = \Drupal::configFactory()->getEditable('filelink_usage.settings');
+  if ($config->get('verbose_logging') === TRUE) {
+    $config->set('verbose_logging', FALSE);
+  }
+  if ($config->get('scan_frequency') === 'daily') {
+    $config->set('scan_frequency', 'yearly');
+  }
+  if ($config->get('scan_frequency') === NULL) {
+    $config->set('scan_frequency', 'yearly');
+  }
+  $config->save();
+}

--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -44,8 +44,10 @@ class FileLinkUsageManager {
       'hourly' => 3600,
       'daily' => 86400,
       'weekly' => 604800,
+      'monthly' => 2592000,
+      'yearly' => 31536000,
     ];
-    $interval = $intervals[$frequency] ?? 86400;
+    $interval = $intervals[$frequency] ?? 31536000;
     $now = $this->time->getRequestTime();
 
     $match_count = (int) $this->database->select('filelink_usage_matches')

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -61,6 +61,8 @@ class SettingsForm extends ConfigFormBase {
         'hourly' => $this->t('Hourly'),
         'daily' => $this->t('Daily'),
         'weekly' => $this->t('Weekly'),
+        'monthly' => $this->t('Monthly'),
+        'yearly' => $this->t('Yearly'),
       ],
       '#default_value' => $config->get('scan_frequency'),
       '#description' => $this->t('How often cron should scan for file links.'),


### PR DESCRIPTION
## Summary
- disable verbose logging by default
- add monthly/yearly cron frequency options and default to yearly
- document default cron frequency in README
- provide an update hook for existing sites

## Testing
- `composer install` *(fails: composer not found)*
- `phpunit -c ./phpunit.xml.dist tests` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3dec04e883318b4193644806acc0