### PR TITLE
Add strict typing declarations

### DIFF
--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Implements hook_schema().

--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\node\NodeInterface;

--- a/src/Commands/FileLinkUsageCommands.php
+++ b/src/Commands/FileLinkUsageCommands.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\filelink_usage\Commands;
 

--- a/src/FileLinkUsageCron.php
+++ b/src/FileLinkUsageCron.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\filelink_usage;
 

--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\filelink_usage;
 

--- a/src/FileLinkUsageNormalizer.php
+++ b/src/FileLinkUsageNormalizer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\filelink_usage;
 

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\filelink_usage;
 

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\filelink_usage\Form;
 


### PR DESCRIPTION
## Summary
- enforce strict types across main PHP files

## Testing
- `php -l filelink_usage.install filelink_usage.module src/Commands/FileLinkUsageCommands.php src/FileLinkUsageCron.php src/FileLinkUsageManager.php src/FileLinkUsageNormalizer.php src/FileLinkUsageScanner.php src/Form/SettingsForm.php`

------
https://chatgpt.com/codex/tasks/task_e_686d4bd2d7bc8331829b962692bb12df