### PR TITLE
Add node delete hook and tests for node hooks

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -51,3 +51,10 @@ function filelink_usage_entity_delete(EntityInterface $entity) {
     \Drupal::service('filelink_usage.manager')->cleanupNode($entity);
   }
 }
+
+/**
+ * Implements hook_node_delete().
+ */
+function filelink_usage_node_delete(NodeInterface $node) {
+  \Drupal::service('filelink_usage.manager')->cleanupNode($node);
+}

--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests automatic scanning via node insert and update hooks.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageNodeHooksTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'filelink_usage',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('node');
+    $this->installSchema('file', ['file_usage']);
+    $this->installConfig(['node', 'filter']);
+
+    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+  }
+
+  /**
+   * Ensures node insert triggers scanning of hard-coded links.
+   */
+  public function testInsertHookScansNode(): void {
+    $uri = 'public://hook_insert.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'txt');
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'hook_insert.txt',
+    ]);
+    $file->save();
+
+    $body = '<a href="/sites/default/files/hook_insert.txt">Download</a>';
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Hook insert',
+      'body' => [
+        'value' => $body,
+        'format' => 'plain_text',
+      ],
+    ]);
+    $node->save();
+
+    $database = $this->container->get('database');
+    $link = $database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('nid', $node->id())
+      ->execute()
+      ->fetchField();
+    $this->assertEquals($uri, $link);
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertArrayHasKey($node->id(), $usage['filelink_usage']['node']);
+  }
+
+  /**
+   * Ensures node update rescans content when links change.
+   */
+  public function testUpdateHookScansNode(): void {
+    $uri = 'public://hook_update.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'txt');
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'hook_update.txt',
+    ]);
+    $file->save();
+
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Hook update',
+      'body' => [
+        'value' => 'Initial body',
+        'format' => 'plain_text',
+      ],
+    ]);
+    $node->save();
+
+    $database = $this->container->get('database');
+    $count = $database->select('filelink_usage_matches')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, $count);
+
+    $node->body->value = '<a href="/sites/default/files/hook_update.txt">Download</a>';
+    $node->save();
+
+    $link = $database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('nid', $node->id())
+      ->execute()
+      ->fetchField();
+    $this->assertEquals($uri, $link);
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertArrayHasKey($node->id(), $usage['filelink_usage']['node']);
+  }
+
+}
+


### PR DESCRIPTION
## Summary
- add `filelink_usage_node_delete` to clear usage when nodes are removed
- add kernel tests to verify insert and update hooks scan nodes

## Testing
- `composer install`
- `phpunit tests/src/Kernel/FileLinkUsageNodeHooksTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*
- `phpunit -c core modules/custom/filelink_usage/tests/src/Kernel` *(fails: Cannot open file)*

------
https://chatgpt.com/codex/tasks/task_e_686d6081a384833184e8994fdc51ee55