### PR TITLE
Add README note about cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The `filelink_usage` module scans all text fields across your Drupal 10 or 11 si
 - ⚙️ Configuration form with verbose logging disabled by default
 - 🧹 Admin UI button to purge stored file link matches
 - 📅 Nodes are re-scanned if their last scan time exceeds the chosen interval
+- 🗑️ Hard-coded file link usages are removed automatically when nodes are deleted
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- document automatic cleanup on node deletion in README

## Testing
- `composer install` *(fails: command not found)*
- `phpunit -c core modules/custom/filelink_usage/tests/src/Kernel` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d790b062c83318a3def4a9afd2c75