### PR TITLE
Fix missing brace causing syntax error

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -170,8 +170,9 @@ class FileLinkUsageScanner {
     return $results;
   }
 
+}
 
-  /**
+/**
    * Scan a single node for file links and update usage.
    */
   public function scanNode(NodeInterface $node): array {


### PR DESCRIPTION
## Summary
- close the `scan()` method in `FileLinkUsageScanner` so the class compiles

## Testing
- `php -l src/FileLinkUsageScanner.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_686e599d7ab48331974f6886ac894760