### PR TITLE
Fix stray brace in FileLinkUsageScanner

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -170,7 +170,6 @@ class FileLinkUsageScanner {
     return $results;
   }
 
-}
 
 /**
    * Scan a single node for file links and update usage.


### PR DESCRIPTION
## Summary
- fix an extra closing brace that ended the class early in FileLinkUsageScanner

## Testing
- `composer install` *(fails: composer not found)*
- `php -l src/FileLinkUsageScanner.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e92f54a648331af78dc9d3427ba64