### PR TITLE
Remove node delete hook duplication

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -53,10 +53,3 @@ function filelink_usage_entity_delete(EntityInterface $entity) {
     \Drupal::service('filelink_usage.manager')->reconcileNodeUsage($entity->id(), TRUE);
   }
 }
-
-/**
- * Implements hook_node_delete().
- */
-function filelink_usage_node_delete(NodeInterface $node) {
-  \Drupal::service('filelink_usage.manager')->reconcileNodeUsage($node->id(), TRUE);
-}

--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -165,7 +165,7 @@ class FileLinkUsageNodeHooksTest extends KernelTestBase {
   }
 
   /**
-   * Ensures node delete removes usage entries via hook_node_delete().
+   * Ensures node delete removes usage entries via entity_delete().
    */
   public function testDeleteHookRemovesUsage(): void {
     $uri = 'public://hook_delete.txt';


### PR DESCRIPTION
## Summary
- delete duplicate `hook_node_delete()` implementation
- rely on `hook_entity_delete()` for cleanup
- adjust tests accordingly

## Testing
- `phpunit -c core modules/custom/filelink_usage/tests/src/Kernel` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e97ac0f288331894f0e0fdf9b2aed