### PR TITLE
Fix reconcileNodeUsage type error

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -25,7 +25,7 @@ function filelink_usage_mark_for_rescan(NodeInterface $node) {
 function filelink_usage_entity_insert(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
     \Drupal::service('filelink_usage.scanner')->scanNode($entity);
-    \Drupal::service('filelink_usage.manager')->reconcileNodeUsage($entity->id());
+    \Drupal::service('filelink_usage.manager')->reconcileNodeUsage((int) $entity->id());
   }
   elseif ($entity instanceof FileInterface) {
     \Drupal::service('filelink_usage.manager')->addUsageForFile($entity);
@@ -38,7 +38,7 @@ function filelink_usage_entity_insert(EntityInterface $entity) {
 function filelink_usage_entity_update(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
     \Drupal::service('filelink_usage.scanner')->scanNode($entity);
-    \Drupal::service('filelink_usage.manager')->reconcileNodeUsage($entity->id());
+    \Drupal::service('filelink_usage.manager')->reconcileNodeUsage((int) $entity->id());
   }
   elseif ($entity instanceof FileInterface) {
     \Drupal::service('filelink_usage.manager')->addUsageForFile($entity);
@@ -50,6 +50,6 @@ function filelink_usage_entity_update(EntityInterface $entity) {
  */
 function filelink_usage_entity_delete(EntityInterface $entity) {
   if ($entity instanceof NodeInterface) {
-    \Drupal::service('filelink_usage.manager')->reconcileNodeUsage($entity->id(), TRUE);
+    \Drupal::service('filelink_usage.manager')->reconcileNodeUsage((int) $entity->id(), TRUE);
   }
 }


### PR DESCRIPTION
## Summary
- cast node IDs to int when reconciling file usage

## Testing
- `composer install` *(fails: command not found)*
- `phpunit -c core modules/custom/filelink_usage/tests/src/Kernel` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea567fe2c83319073c2851bb0ffab