### PR TITLE
Enable scanning for non-node entities

### DIFF
--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -6,14 +6,19 @@ declare(strict_types=1);
  */
 function filelink_usage_schema() {
   $schema['filelink_usage_matches'] = [
-    'description' => 'Stores detected file links in node text fields.',
+    'description' => 'Stores detected file links in content entity text fields.',
     'fields' => [
       'id' => [
         'type' => 'serial',
         'unsigned' => TRUE,
         'not null' => TRUE,
       ],
-      'nid' => [
+      'entity_type' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+      ],
+      'entity_id' => [
         'type' => 'int',
         'unsigned' => TRUE,
         'not null' => TRUE,
@@ -30,18 +35,24 @@ function filelink_usage_schema() {
     ],
     'primary key' => ['id'],
     'indexes' => [
-      'nid' => ['nid'],
+      'entity_type' => ['entity_type'],
+      'entity_id' => ['entity_id'],
       'link' => ['link'],
     ],
     'unique keys' => [
-      'nid_link' => ['nid', 'link'],
+      'entity_link' => ['entity_type', 'entity_id', 'link'],
     ],
   ];
 
   $schema['filelink_usage_scan_status'] = [
-    'description' => 'Tracks the last successful scan time for each node.',
+    'description' => 'Tracks the last successful scan time for each content entity.',
     'fields' => [
-      'nid' => [
+      'entity_type' => [
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+      ],
+      'entity_id' => [
         'type' => 'int',
         'unsigned' => TRUE,
         'not null' => TRUE,
@@ -51,7 +62,7 @@ function filelink_usage_schema() {
         'not null' => TRUE,
       ],
     ],
-    'primary key' => ['nid'],
+    'primary key' => ['entity_type', 'entity_id'],
   ];
   return $schema;
 }

--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\node\NodeInterface;
 use Drupal\file\FileInterface;
 
@@ -23,12 +24,12 @@ function filelink_usage_mark_for_rescan(NodeInterface $node) {
  * Implements hook_entity_insert().
  */
 function filelink_usage_entity_insert(EntityInterface $entity) {
-  if ($entity instanceof NodeInterface) {
-    \Drupal::service('filelink_usage.scanner')->scanNode($entity);
-    \Drupal::service('filelink_usage.manager')->reconcileNodeUsage((int) $entity->id());
-  }
-  elseif ($entity instanceof FileInterface) {
+  if ($entity instanceof FileInterface) {
     \Drupal::service('filelink_usage.manager')->addUsageForFile($entity);
+  }
+  elseif ($entity instanceof ContentEntityInterface) {
+    \Drupal::service('filelink_usage.scanner')->scan([$entity->id()], $entity->getEntityTypeId());
+    \Drupal::service('filelink_usage.manager')->reconcileEntityUsage($entity->getEntityTypeId(), (int) $entity->id());
   }
 }
 
@@ -36,12 +37,12 @@ function filelink_usage_entity_insert(EntityInterface $entity) {
  * Implements hook_entity_update().
  */
 function filelink_usage_entity_update(EntityInterface $entity) {
-  if ($entity instanceof NodeInterface) {
-    \Drupal::service('filelink_usage.scanner')->scanNode($entity);
-    \Drupal::service('filelink_usage.manager')->reconcileNodeUsage((int) $entity->id());
-  }
-  elseif ($entity instanceof FileInterface) {
+  if ($entity instanceof FileInterface) {
     \Drupal::service('filelink_usage.manager')->addUsageForFile($entity);
+  }
+  elseif ($entity instanceof ContentEntityInterface) {
+    \Drupal::service('filelink_usage.scanner')->scan([$entity->id()], $entity->getEntityTypeId());
+    \Drupal::service('filelink_usage.manager')->reconcileEntityUsage($entity->getEntityTypeId(), (int) $entity->id());
   }
 }
 
@@ -49,7 +50,7 @@ function filelink_usage_entity_update(EntityInterface $entity) {
  * Implements hook_entity_delete().
  */
 function filelink_usage_entity_delete(EntityInterface $entity) {
-  if ($entity instanceof NodeInterface) {
-    \Drupal::service('filelink_usage.manager')->reconcileNodeUsage((int) $entity->id(), TRUE);
+  if ($entity instanceof ContentEntityInterface && !$entity instanceof FileInterface) {
+    \Drupal::service('filelink_usage.manager')->reconcileEntityUsage($entity->getEntityTypeId(), (int) $entity->id(), TRUE);
   }
 }

--- a/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\file\Entity\File;
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests automatic scanning via block insert hooks.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageBlockContentHooksTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'block',
+    'block_content',
+    'filelink_usage',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('block_content');
+    $this->installSchema('file', ['file_usage']);
+    $this->installConfig(['node', 'block_content', 'filter']);
+
+    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    BlockContentType::create(['id' => 'basic', 'label' => 'Basic'])->save();
+  }
+
+  /**
+   * Ensures node insert triggers scanning of hard-coded links.
+   */
+  public function testInsertHookScansBlock(): void {
+    $uri = 'public://hook_insert.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'txt');
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'hook_insert.txt',
+    ]);
+    $file->save();
+
+    $body = '<a href="/sites/default/files/hook_insert.txt">Download</a>';
+    $block = BlockContent::create([
+      'type' => 'basic',
+      'info' => 'Hook insert',
+      'body' => [
+        'value' => $body,
+        'format' => 'plain_text',
+      ],
+    ]);
+    $block->save();
+
+    $database = $this->container->get('database');
+    $link = $database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('entity_type', 'block_content')
+      ->condition('entity_id', $block->id())
+      ->execute()
+      ->fetchField();
+    $this->assertEquals($uri, $link);
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertArrayHasKey($block->id(), $usage['filelink_usage']['block_content']);
+  }
+
+
+}
+

--- a/tests/src/Kernel/FileLinkUsageCleanupTest.php
+++ b/tests/src/Kernel/FileLinkUsageCleanupTest.php
@@ -105,14 +105,16 @@ class FileLinkUsageCleanupTest extends KernelTestBase {
     $database = $this->container->get('database');
     $database->insert('filelink_usage_matches')
       ->fields([
-        'nid' => $node->id(),
+        'entity_type' => 'node',
+        'entity_id' => $node->id(),
         'link' => $uri,
         'timestamp' => $this->container->get('datetime.time')->getRequestTime(),
       ])
       ->execute();
     $database->insert('filelink_usage_scan_status')
       ->fields([
-        'nid' => $node->id(),
+        'entity_type' => 'node',
+        'entity_id' => $node->id(),
         'scanned' => $this->container->get('datetime.time')->getRequestTime(),
       ])
       ->execute();

--- a/tests/src/Kernel/FileLinkUsageFileHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileHooksTest.php
@@ -62,7 +62,8 @@ class FileLinkUsageFileHooksTest extends KernelTestBase {
     $database = $this->container->get('database');
     $link = $database->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
-      ->condition('nid', $node->id())
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
       ->execute()
       ->fetchField();
     $this->assertEquals($uri, $link);

--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -69,7 +69,8 @@ class FileLinkUsageNodeHooksTest extends KernelTestBase {
     $database = $this->container->get('database');
     $link = $database->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
-      ->condition('nid', $node->id())
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
       ->execute()
       ->fetchField();
     $this->assertEquals($uri, $link);
@@ -111,7 +112,8 @@ class FileLinkUsageNodeHooksTest extends KernelTestBase {
 
     $link = $database->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
-      ->condition('nid', $node->id())
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
       ->execute()
       ->fetchField();
     $this->assertEquals($uri, $link);

--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -109,7 +109,8 @@ class FileLinkUsageScannerTest extends KernelTestBase {
 
     $link = $this->container->get('database')->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
-      ->condition('nid', $node->id())
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
       ->execute()
       ->fetchField();
 
@@ -156,7 +157,8 @@ class FileLinkUsageScannerTest extends KernelTestBase {
 
     $links = $this->container->get('database')->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
-      ->condition('nid', $node->id())
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
       ->execute()
       ->fetchCol();
 
@@ -199,7 +201,8 @@ class FileLinkUsageScannerTest extends KernelTestBase {
 
     $link = $this->container->get('database')->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
-      ->condition('nid', $node->id())
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
       ->execute()
       ->fetchField();
 
@@ -245,7 +248,8 @@ class FileLinkUsageScannerTest extends KernelTestBase {
     $scanner->scan([$node->id()]);
     $link = $database->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
-      ->condition('nid', $node->id())
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
       ->execute()
       ->fetchField();
 


### PR DESCRIPTION
## Summary
- generalize scanner to handle any content entity type
- track matches by entity type and ID
- reconcile file usage for generic entities
- update entity hooks to scan any content entity
- add kernel test for custom block scanning

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eacff26d88331975a06c986f3708e