### PR TITLE
Update scanner service arguments

### DIFF
--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -4,7 +4,7 @@ services:
 
   filelink_usage.scanner:
     class: Drupal\filelink_usage\FileLinkUsageScanner
-    arguments: ['@entity_type.manager', '@database', '@file.usage', '@logger.channel.filelink_usage', '@config.factory', '@filelink_usage.normalizer', '@datetime.time']
+    arguments: ['@entity_type.manager', '@renderer', '@database', '@file.usage', '@config.factory', '@datetime.time', '@logger.channel.filelink_usage']
     tags:
       - { name: default }
 


### PR DESCRIPTION
## Summary
- remove normalizer from `filelink_usage.scanner` service
- add `@renderer` second in scanner arguments

## Testing
- `python3 - <<'PY'
import sys
print('python available')
PY`
- `drush --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9971e1808331abeee7d8564e059d