### PR TITLE
Fix FileLinkUsageScanner service arguments

### DIFF
--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -4,7 +4,14 @@ services:
 
   filelink_usage.scanner:
     class: Drupal\filelink_usage\FileLinkUsageScanner
-    arguments: ['@entity_type.manager', '@renderer', '@database', '@file.usage', '@config.factory', '@datetime.time', '@logger.channel.filelink_usage']
+    arguments:
+      - '@entity_type.manager'
+      - '@renderer'
+      - '@database'
+      - '@file.usage'
+      - '@config.factory'
+      - '@datetime.time'
+      - '@logger.channel.filelink_usage'
     tags:
       - { name: default }
 


### PR DESCRIPTION
## Summary
- reformat the FileLinkUsageScanner service arguments

## Testing
- `composer validate --no-check-all --strict` *(fails: composer not found)*
- `phpunit --version` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9be355308331ab3f553882d6cd10