### PR TITLE
Fix Cron scan call

### DIFF
--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -113,13 +113,17 @@ class FileLinkUsageManager {
         ->fetchCol();
     }
 
-    // Perform the scan and reconcile usage for each affected node.
-    if (!empty($nids)) {
-      $this->scanner->scan($nids);
-      foreach ($nids as $nid) {
-        $this->reconcileNodeUsage((int) $nid);
+      // Perform the scan and reconcile usage for each affected node.
+      if (!empty($nids)) {
+        // Scanner::scan() expects entity IDs keyed by type.  Previously the
+        // list of node IDs was passed directly, resulting in numeric keys and
+        // an invalid entity type "0".  Wrap the IDs using the node entity type
+        // to avoid PluginNotFoundException.
+        $this->scanner->scan(['node' => $nids]);
+        foreach ($nids as $nid) {
+          $this->reconcileNodeUsage((int) $nid);
+        }
       }
-    }
     // Update the last scan timestamp.
     $config->set('last_scan', $now)->save();
   }


### PR DESCRIPTION
## Summary
- ensure filelink_usage's cron uses scanner with correct entity type array

## Testing
- `php -l src/FileLinkUsageManager.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9dcc62648331b533be198c5ea63f