### PR TITLE
Allow entity ID string in reconcileEntityUsage

### DIFF
--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -164,9 +164,17 @@ class FileLinkUsageManager {
    */
   public function reconcileEntityUsage(
     string $entity_type_id,
-    int $entity_id,
+    int|string $entity_id,
     bool $deleted = FALSE
   ): void {
+    if (is_string($entity_id)) {
+      if (ctype_digit($entity_id)) {
+        $entity_id = (int) $entity_id;
+      }
+      else {
+        return;
+      }
+    }
     if ($deleted) {
       $this->purgeEntityUsage($entity_type_id, $entity_id);
     }


### PR DESCRIPTION
## Summary
- allow `FileLinkUsageManager::reconcileEntityUsage()` to accept entity IDs as `int|string`
- convert string entity IDs to integers when possible

## Testing
- `php -l src/FileLinkUsageManager.php`
- `composer validate --no-check-all --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68727f1c7ed0833191ae7ad307b3b114