### PR TITLE
Install module schema for kernel tests

### DIFF
--- a/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
@@ -42,6 +42,10 @@ class FileLinkUsageBlockContentHooksTest extends KernelTestBase {
     $this->installEntitySchema('node');
     $this->installEntitySchema('block_content');
     $this->installSchema('file', ['file_usage']);
+    $this->installSchema('filelink_usage', [
+      'filelink_usage_matches',
+      'filelink_usage_scan_status',
+    ]);
     $this->installConfig(['node', 'block_content', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();

--- a/tests/src/Kernel/FileLinkUsageCleanupTest.php
+++ b/tests/src/Kernel/FileLinkUsageCleanupTest.php
@@ -38,6 +38,10 @@ class FileLinkUsageCleanupTest extends KernelTestBase {
     $this->installEntitySchema('file');
     $this->installEntitySchema('node');
     $this->installSchema('file', ['file_usage']);
+    $this->installSchema('filelink_usage', [
+      'filelink_usage_matches',
+      'filelink_usage_scan_status',
+    ]);
     $this->installConfig(['node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();

--- a/tests/src/Kernel/FileLinkUsageFileHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileHooksTest.php
@@ -38,6 +38,10 @@ class FileLinkUsageFileHooksTest extends KernelTestBase {
     $this->installEntitySchema('file');
     $this->installEntitySchema('node');
     $this->installSchema('file', ['file_usage']);
+    $this->installSchema('filelink_usage', [
+      'filelink_usage_matches',
+      'filelink_usage_scan_status',
+    ]);
     $this->installConfig(['node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();

--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -38,6 +38,10 @@ class FileLinkUsageNodeHooksTest extends KernelTestBase {
     $this->installEntitySchema('file');
     $this->installEntitySchema('node');
     $this->installSchema('file', ['file_usage']);
+    $this->installSchema('filelink_usage', [
+      'filelink_usage_matches',
+      'filelink_usage_scan_status',
+    ]);
     $this->installConfig(['node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();

--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -40,6 +40,10 @@ class FileLinkUsagePurgeTest extends KernelTestBase {
     $this->installEntitySchema('file');
     $this->installEntitySchema('node');
     $this->installSchema('file', ['file_usage']);
+    $this->installSchema('filelink_usage', [
+      'filelink_usage_matches',
+      'filelink_usage_scan_status',
+    ]);
     $this->installConfig(['node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();

--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -38,6 +38,10 @@ class FileLinkUsageReconcileTest extends KernelTestBase {
     $this->installEntitySchema('file');
     $this->installEntitySchema('node');
     $this->installSchema('file', ['file_usage']);
+    $this->installSchema('filelink_usage', [
+      'filelink_usage_matches',
+      'filelink_usage_scan_status',
+    ]);
     $this->installConfig(['node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();

--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -38,6 +38,10 @@ class FileLinkUsageScannerTest extends KernelTestBase {
     $this->installEntitySchema('file');
     $this->installEntitySchema('node');
     $this->installSchema('file', ['file_usage']);
+    $this->installSchema('filelink_usage', [
+      'filelink_usage_matches',
+      'filelink_usage_scan_status',
+    ]);
     $this->installConfig(['node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();


### PR DESCRIPTION
## Summary
- install `filelink_usage` schema in kernel test setup

## Testing
- `composer --no-interaction test` *(fails: Command "test" is not defined)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872abf9b4f48331a7d63c3068c388ec