### PR TITLE
Fix Drupal 11 compatibility

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -36,7 +36,7 @@ function filelink_usage_entity_insert(EntityInterface $entity): void {
     default:
       // Newly created content may contain hard‑coded links – rescan next cron.
       $entity_type = $entity->getEntityType();
-      if ($entity_type instanceof ContentEntityTypeInterface && $entity_type->isContent()) {
+      if ($entity_type instanceof ContentEntityTypeInterface) {
         $manager->markEntityForScan($entity->getEntityTypeId(), $entity->id());
       }
   }
@@ -48,7 +48,7 @@ function filelink_usage_entity_insert(EntityInterface $entity): void {
 function filelink_usage_entity_update(EntityInterface $entity): void {
   // Any content edit might add/remove links – mark for re‑scan.
   $entity_type = $entity->getEntityType();
-  if ($entity_type instanceof ContentEntityTypeInterface && $entity_type->isContent()) {
+  if ($entity_type instanceof ContentEntityTypeInterface) {
     \Drupal::service('filelink_usage.manager')
       ->markEntityForScan($entity->getEntityTypeId(), $entity->id());
   }
@@ -74,7 +74,7 @@ function filelink_usage_entity_delete(EntityInterface $entity): void {
     default:
       // Purge any usage rows for other content entity types.
       $entity_type = $entity->getEntityType();
-      if ($entity_type instanceof ContentEntityTypeInterface && $entity_type->isContent()) {
+      if ($entity_type instanceof ContentEntityTypeInterface) {
         $manager->reconcileEntityUsage($entity->getEntityTypeId(), $entity->id(), TRUE);
       }
   }


### PR DESCRIPTION
## Summary
- avoid calling non-existent ContentEntityType::isContent method

## Testing
- `apt-get install -y phpunit`
- `phpunit -c phpunit.xml tests/src/Kernel --group filelink_usage` *(fails: Could not read "phpunit.xml")*

------
https://chatgpt.com/codex/tasks/task_e_6872b1ee0e548331ab589e6e7c0374ee