### PR TITLE
Update scanner test calls

### DIFF
--- a/tests/src/Kernel/FileLinkUsageCleanupTest.php
+++ b/tests/src/Kernel/FileLinkUsageCleanupTest.php
@@ -70,7 +70,7 @@ class FileLinkUsageCleanupTest extends KernelTestBase {
     ]);
     $node->save();
 
-    $this->container->get('filelink_usage.scanner')->scan([$node->id()]);
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
 
     $database = $this->container->get('database');
     $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();

--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -73,7 +73,7 @@ class FileLinkUsagePurgeTest extends KernelTestBase {
     $node->save();
 
     // Initial scan to populate tables.
-    $this->container->get('filelink_usage.scanner')->scan([$node->id()]);
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
 
     $database = $this->container->get('database');
     $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();
@@ -158,7 +158,7 @@ class FileLinkUsagePurgeTest extends KernelTestBase {
     ]);
     $node->save();
 
-    $this->container->get('filelink_usage.scanner')->scan([$node->id()]);
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
 
     $database = $this->container->get('database');
 

--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -85,7 +85,7 @@ class FileLinkUsageReconcileTest extends KernelTestBase {
     $node->save();
 
     // Initial scan.
-    $this->container->get('filelink_usage.scanner')->scan([$node->id()]);
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
 
     $database = $this->container->get('database');
     // Remove usage for the real file and add usage for another file.

--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -74,8 +74,8 @@ class FileLinkUsageScannerTest extends KernelTestBase {
 
     // Run the scanner twice for the same node.
     $scanner = $this->container->get('filelink_usage.scanner');
-    $scanner->scan([$node->id()]);
-    $scanner->scan([$node->id()]);
+    $scanner->scan(['node' => [$node->id()]]);
+    $scanner->scan(['node' => [$node->id()]]);
 
     // Validate only a single usage row exists.
     $usage = $this->container->get('file.usage')->listUsage($file);
@@ -109,7 +109,7 @@ class FileLinkUsageScannerTest extends KernelTestBase {
     ]);
     $node->save();
 
-    $this->container->get('filelink_usage.scanner')->scan([$node->id()]);
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
 
     $link = $this->container->get('database')->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
@@ -157,7 +157,7 @@ class FileLinkUsageScannerTest extends KernelTestBase {
     ]);
     $node->save();
 
-    $this->container->get('filelink_usage.scanner')->scan([$node->id()]);
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
 
     $links = $this->container->get('database')->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
@@ -201,7 +201,7 @@ class FileLinkUsageScannerTest extends KernelTestBase {
     ]);
     $node->save();
 
-    $this->container->get('filelink_usage.scanner')->scan([$node->id()]);
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
 
     $link = $this->container->get('database')->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
@@ -239,7 +239,7 @@ class FileLinkUsageScannerTest extends KernelTestBase {
     $node->save();
 
     $scanner = $this->container->get('filelink_usage.scanner');
-    $scanner->scan([$node->id()]);
+    $scanner->scan(['node' => [$node->id()]]);
 
     $database = $this->container->get('database');
     $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();
@@ -249,7 +249,7 @@ class FileLinkUsageScannerTest extends KernelTestBase {
     $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();
     $this->assertEquals(0, $count);
 
-    $scanner->scan([$node->id()]);
+    $scanner->scan(['node' => [$node->id()]]);
     $link = $database->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
       ->condition('entity_type', 'node')


### PR DESCRIPTION
## Summary
- update kernel tests to pass entity IDs keyed by type

## Testing
- `php -l tests/src/Kernel/FileLinkUsagePurgeTest.php tests/src/Kernel/FileLinkUsageCleanupTest.php tests/src/Kernel/FileLinkUsageReconcileTest.php tests/src/Kernel/FileLinkUsageScannerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_6872ba4156648331836644c4210c63d7