### PR TITLE
Fix scan status insertion in manual cleanup test

### DIFF
--- a/tests/src/Kernel/FileLinkUsageCleanupTest.php
+++ b/tests/src/Kernel/FileLinkUsageCleanupTest.php
@@ -115,11 +115,14 @@ class FileLinkUsageCleanupTest extends KernelTestBase {
         'timestamp' => $this->container->get('datetime.time')->getRequestTime(),
       ])
       ->execute();
-    $database->insert('filelink_usage_scan_status')
-      ->fields([
+    $timestamp = $this->container->get('datetime.time')->getRequestTime();
+    $database->merge('filelink_usage_scan_status')
+      ->keys([
         'entity_type' => 'node',
         'entity_id' => $node->id(),
-        'scanned' => $this->container->get('datetime.time')->getRequestTime(),
+      ])
+      ->fields([
+        'scanned' => $timestamp,
       ])
       ->execute();
 


### PR DESCRIPTION
## Summary
- prevent primary key violation by using merge() when inserting a scan status row in FileLinkUsageCleanupTest

## Testing
- `php -l tests/src/Kernel/FileLinkUsageCleanupTest.php`
- `phpunit -v tests/src/Kernel/FileLinkUsageCleanupTest.php` *(fails: Class `Drupal\KernelTests\KernelTestBase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c8463c2c8331994070f3a770ba18