### PR TITLE
Fix cron tests with missing entity schemas

### DIFF
--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -27,6 +27,10 @@ class FileLinkUsagePurgeTest extends KernelTestBase {
     'text',
     'file',
     'node',
+    'block',
+    'block_content',
+    'taxonomy',
+    'comment',
     'filelink_usage',
   ];
 
@@ -39,6 +43,9 @@ class FileLinkUsagePurgeTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installEntitySchema('file');
     $this->installEntitySchema('node');
+    $this->installEntitySchema('block_content');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('comment');
     $this->installSchema('file', ['file_usage']);
     $this->installSchema('filelink_usage', [
       'filelink_usage_matches',


### PR DESCRIPTION
## Summary
- load extra entity modules for purge/cron tests
- install `block_content`, `taxonomy_term` and `comment` schemas in `FileLinkUsagePurgeTest`

## Testing
- `vendor/bin/phpunit -c vendor/drupal/core/phpunit.xml.dist tests/src/Kernel/FileLinkUsagePurgeTest.php` *(fails: Error in bootstrap script)*

------
https://chatgpt.com/codex/tasks/task_e_6872c968e7848331bf0cd68557baa26a