### PR TITLE
Fix missing config in kernel tests

### DIFF
--- a/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
@@ -46,7 +46,8 @@ class FileLinkUsageBlockContentHooksTest extends KernelTestBase {
       'filelink_usage_matches',
       'filelink_usage_scan_status',
     ]);
-    $this->installConfig(['node', 'block_content', 'filter']);
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'block_content', 'filter', 'system']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
     BlockContentType::create(['id' => 'basic', 'label' => 'Basic'])->save();

--- a/tests/src/Kernel/FileLinkUsageCleanupTest.php
+++ b/tests/src/Kernel/FileLinkUsageCleanupTest.php
@@ -42,7 +42,8 @@ class FileLinkUsageCleanupTest extends KernelTestBase {
       'filelink_usage_matches',
       'filelink_usage_scan_status',
     ]);
-    $this->installConfig(['node', 'filter']);
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'filter', 'system']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsageFileHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileHooksTest.php
@@ -42,7 +42,8 @@ class FileLinkUsageFileHooksTest extends KernelTestBase {
       'filelink_usage_matches',
       'filelink_usage_scan_status',
     ]);
-    $this->installConfig(['node', 'filter']);
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'filter', 'system']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -42,7 +42,8 @@ class FileLinkUsageNodeHooksTest extends KernelTestBase {
       'filelink_usage_matches',
       'filelink_usage_scan_status',
     ]);
-    $this->installConfig(['node', 'filter']);
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'filter', 'system']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -51,7 +51,8 @@ class FileLinkUsagePurgeTest extends KernelTestBase {
       'filelink_usage_matches',
       'filelink_usage_scan_status',
     ]);
-    $this->installConfig(['node', 'filter']);
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'filter', 'system']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -42,7 +42,8 @@ class FileLinkUsageReconcileTest extends KernelTestBase {
       'filelink_usage_matches',
       'filelink_usage_scan_status',
     ]);
-    $this->installConfig(['node', 'filter']);
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'filter', 'system']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -42,7 +42,8 @@ class FileLinkUsageScannerTest extends KernelTestBase {
       'filelink_usage_matches',
       'filelink_usage_scan_status',
     ]);
-    $this->installConfig(['node', 'filter']);
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'filter', 'system']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }


### PR DESCRIPTION
## Summary
- install the system config in all kernel tests
- install node_access schema during setup

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml tests/src/Kernel --group filelink_usage` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6872cdfd5fc88331b997248a709d9c8e