### PR TITLE
Fix installConfig order in kernel tests

### DIFF
--- a/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
@@ -47,7 +47,7 @@ class FileLinkUsageBlockContentHooksTest extends KernelTestBase {
       'filelink_usage_scan_status',
     ]);
     $this->installSchema('node', ['node_access']);
-    $this->installConfig(['node', 'block_content', 'filter', 'system']);
+    $this->installConfig(['system', 'node', 'block_content', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
     BlockContentType::create(['id' => 'basic', 'label' => 'Basic'])->save();

--- a/tests/src/Kernel/FileLinkUsageCleanupTest.php
+++ b/tests/src/Kernel/FileLinkUsageCleanupTest.php
@@ -43,7 +43,7 @@ class FileLinkUsageCleanupTest extends KernelTestBase {
       'filelink_usage_scan_status',
     ]);
     $this->installSchema('node', ['node_access']);
-    $this->installConfig(['node', 'filter', 'system']);
+    $this->installConfig(['system', 'node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsageFileHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileHooksTest.php
@@ -43,7 +43,7 @@ class FileLinkUsageFileHooksTest extends KernelTestBase {
       'filelink_usage_scan_status',
     ]);
     $this->installSchema('node', ['node_access']);
-    $this->installConfig(['node', 'filter', 'system']);
+    $this->installConfig(['system', 'node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -43,7 +43,7 @@ class FileLinkUsageNodeHooksTest extends KernelTestBase {
       'filelink_usage_scan_status',
     ]);
     $this->installSchema('node', ['node_access']);
-    $this->installConfig(['node', 'filter', 'system']);
+    $this->installConfig(['system', 'node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -52,7 +52,7 @@ class FileLinkUsagePurgeTest extends KernelTestBase {
       'filelink_usage_scan_status',
     ]);
     $this->installSchema('node', ['node_access']);
-    $this->installConfig(['node', 'filter', 'system']);
+    $this->installConfig(['system', 'node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -43,7 +43,7 @@ class FileLinkUsageReconcileTest extends KernelTestBase {
       'filelink_usage_scan_status',
     ]);
     $this->installSchema('node', ['node_access']);
-    $this->installConfig(['node', 'filter', 'system']);
+    $this->installConfig(['system', 'node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }

--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -43,7 +43,7 @@ class FileLinkUsageScannerTest extends KernelTestBase {
       'filelink_usage_scan_status',
     ]);
     $this->installSchema('node', ['node_access']);
-    $this->installConfig(['node', 'filter', 'system']);
+    $this->installConfig(['system', 'node', 'filter']);
 
     NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
   }


### PR DESCRIPTION
## Summary
- include `system` configuration first in kernel tests

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687364a0b2188331a560d2f00888e089