### PR TITLE
Ensure body field added in Kernel tests

### DIFF
--- a/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
@@ -49,7 +49,12 @@ class FileLinkUsageBlockContentHooksTest extends KernelTestBase {
     $this->installSchema('node', ['node_access']);
     $this->installConfig(['system', 'node', 'block_content', 'filter']);
 
-    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $node_type->save();
+    node_add_body_field($node_type);
     BlockContentType::create(['id' => 'basic', 'label' => 'Basic'])->save();
   }
 

--- a/tests/src/Kernel/FileLinkUsageCleanupTest.php
+++ b/tests/src/Kernel/FileLinkUsageCleanupTest.php
@@ -45,7 +45,12 @@ class FileLinkUsageCleanupTest extends KernelTestBase {
     $this->installSchema('node', ['node_access']);
     $this->installConfig(['system', 'node', 'filter']);
 
-    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $node_type->save();
+    node_add_body_field($node_type);
   }
 
   /**

--- a/tests/src/Kernel/FileLinkUsageFileHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileHooksTest.php
@@ -45,7 +45,12 @@ class FileLinkUsageFileHooksTest extends KernelTestBase {
     $this->installSchema('node', ['node_access']);
     $this->installConfig(['system', 'node', 'filter']);
 
-    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $node_type->save();
+    node_add_body_field($node_type);
   }
 
   /**

--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -45,7 +45,12 @@ class FileLinkUsageNodeHooksTest extends KernelTestBase {
     $this->installSchema('node', ['node_access']);
     $this->installConfig(['system', 'node', 'filter']);
 
-    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $node_type->save();
+    node_add_body_field($node_type);
   }
 
   /**

--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -54,7 +54,12 @@ class FileLinkUsagePurgeTest extends KernelTestBase {
     $this->installSchema('node', ['node_access']);
     $this->installConfig(['system', 'node', 'filter']);
 
-    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $node_type->save();
+    node_add_body_field($node_type);
   }
 
   /**

--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -45,7 +45,12 @@ class FileLinkUsageReconcileTest extends KernelTestBase {
     $this->installSchema('node', ['node_access']);
     $this->installConfig(['system', 'node', 'filter']);
 
-    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $node_type->save();
+    node_add_body_field($node_type);
   }
 
   /**

--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -45,7 +45,12 @@ class FileLinkUsageScannerTest extends KernelTestBase {
     $this->installSchema('node', ['node_access']);
     $this->installConfig(['system', 'node', 'filter']);
 
-    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $node_type->save();
+    node_add_body_field($node_type);
   }
 
   /**


### PR DESCRIPTION
## Summary
- install body field using `node_add_body_field()` for article content type in every Kernel test setup

## Testing
- `vendor/bin/phpunit tests/src/Kernel` *(fails: Class `Drupal\KernelTests\KernelTestBase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68736692a6a483318311578769b0ba6c