### PR TITLE
Refactor kernel tests to use common base

### DIFF
--- a/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
@@ -2,18 +2,17 @@
 
 namespace Drupal\Tests\filelink_usage\Kernel;
 
-use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase;
 use Drupal\file\Entity\File;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\block_content\Entity\BlockContentType;
-use Drupal\node\Entity\NodeType;
 
 /**
  * Tests automatic scanning via block insert hooks.
  *
  * @group filelink_usage
  */
-class FileLinkUsageBlockContentHooksTest extends KernelTestBase {
+class FileLinkUsageBlockContentHooksTest extends FileLinkUsageKernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -37,24 +36,9 @@ class FileLinkUsageBlockContentHooksTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('file');
-    $this->installEntitySchema('node');
     $this->installEntitySchema('block_content');
-    $this->installSchema('file', ['file_usage']);
-    $this->installSchema('filelink_usage', [
-      'filelink_usage_matches',
-      'filelink_usage_scan_status',
-    ]);
-    $this->installSchema('node', ['node_access']);
-    $this->installConfig(['system', 'node', 'block_content', 'filter']);
+    $this->installConfig(['block_content']);
 
-    $node_type = NodeType::create([
-      'type' => 'article',
-      'name' => 'Article',
-    ]);
-    $node_type->save();
-    node_add_body_field($node_type);
     BlockContentType::create(['id' => 'basic', 'label' => 'Basic'])->save();
   }
 

--- a/tests/src/Kernel/FileLinkUsageCleanupTest.php
+++ b/tests/src/Kernel/FileLinkUsageCleanupTest.php
@@ -2,17 +2,16 @@
 
 namespace Drupal\Tests\filelink_usage\Kernel;
 
-use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase;
 use Drupal\file\Entity\File;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 
 /**
  * Tests cleanup of file link matches when nodes are deleted.
  *
  * @group filelink_usage
  */
-class FileLinkUsageCleanupTest extends KernelTestBase {
+class FileLinkUsageCleanupTest extends FileLinkUsageKernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -28,30 +27,6 @@ class FileLinkUsageCleanupTest extends KernelTestBase {
     'filelink_usage',
   ];
 
-  /**
-   * {@inheritdoc}
-   */
-  protected function setUp(): void {
-    parent::setUp();
-
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('file');
-    $this->installEntitySchema('node');
-    $this->installSchema('file', ['file_usage']);
-    $this->installSchema('filelink_usage', [
-      'filelink_usage_matches',
-      'filelink_usage_scan_status',
-    ]);
-    $this->installSchema('node', ['node_access']);
-    $this->installConfig(['system', 'node', 'filter']);
-
-    $node_type = NodeType::create([
-      'type' => 'article',
-      'name' => 'Article',
-    ]);
-    $node_type->save();
-    node_add_body_field($node_type);
-  }
 
   /**
    * Ensures cleanupNode removes matches and usage on node deletion.

--- a/tests/src/Kernel/FileLinkUsageFileHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileHooksTest.php
@@ -2,17 +2,16 @@
 
 namespace Drupal\Tests\filelink_usage\Kernel;
 
-use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase;
 use Drupal\file\Entity\File;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 
 /**
  * Tests file insert hooks create usage for saved links.
  *
  * @group filelink_usage
  */
-class FileLinkUsageFileHooksTest extends KernelTestBase {
+class FileLinkUsageFileHooksTest extends FileLinkUsageKernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -31,27 +30,6 @@ class FileLinkUsageFileHooksTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp(): void {
-    parent::setUp();
-
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('file');
-    $this->installEntitySchema('node');
-    $this->installSchema('file', ['file_usage']);
-    $this->installSchema('filelink_usage', [
-      'filelink_usage_matches',
-      'filelink_usage_scan_status',
-    ]);
-    $this->installSchema('node', ['node_access']);
-    $this->installConfig(['system', 'node', 'filter']);
-
-    $node_type = NodeType::create([
-      'type' => 'article',
-      'name' => 'Article',
-    ]);
-    $node_type->save();
-    node_add_body_field($node_type);
-  }
 
   /**
    * Ensures file entity creation adds usage for saved links.

--- a/tests/src/Kernel/FileLinkUsageKernelTestBase.php
+++ b/tests/src/Kernel/FileLinkUsageKernelTestBase.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Provides common setup for filelink_usage kernel tests.
+ */
+abstract class FileLinkUsageKernelTestBase extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('node');
+    $this->installSchema('file', ['file_usage']);
+    $this->installSchema('filelink_usage', [
+      'filelink_usage_matches',
+      'filelink_usage_scan_status',
+    ]);
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['system', 'node', 'filter']);
+
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $node_type->save();
+    node_add_body_field($node_type);
+  }
+
+}

--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -2,17 +2,16 @@
 
 namespace Drupal\Tests\filelink_usage\Kernel;
 
-use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase;
 use Drupal\file\Entity\File;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 
 /**
  * Tests automatic scanning via node insert and update hooks.
  *
  * @group filelink_usage
  */
-class FileLinkUsageNodeHooksTest extends KernelTestBase {
+class FileLinkUsageNodeHooksTest extends FileLinkUsageKernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -31,28 +30,6 @@ class FileLinkUsageNodeHooksTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp(): void {
-    parent::setUp();
-
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('file');
-    $this->installEntitySchema('node');
-    $this->installSchema('file', ['file_usage']);
-    $this->installSchema('filelink_usage', [
-      'filelink_usage_matches',
-      'filelink_usage_scan_status',
-    ]);
-    $this->installSchema('node', ['node_access']);
-    $this->installConfig(['system', 'node', 'filter']);
-
-    $node_type = NodeType::create([
-      'type' => 'article',
-      'name' => 'Article',
-    ]);
-    $node_type->save();
-    node_add_body_field($node_type);
-  }
-
   /**
    * Ensures node insert triggers scanning of hard-coded links.
    */

--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -2,10 +2,9 @@
 
 namespace Drupal\Tests\filelink_usage\Kernel;
 
-use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase;
 use Drupal\file\Entity\File;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 use Drupal\Core\Form\FormState;
 use Drupal\filelink_usage\Form\SettingsForm;
 
@@ -14,7 +13,7 @@ use Drupal\filelink_usage\Form\SettingsForm;
  *
  * @group filelink_usage
  */
-class FileLinkUsagePurgeTest extends KernelTestBase {
+class FileLinkUsagePurgeTest extends FileLinkUsageKernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -40,26 +39,9 @@ class FileLinkUsagePurgeTest extends KernelTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('file');
-    $this->installEntitySchema('node');
     $this->installEntitySchema('block_content');
     $this->installEntitySchema('taxonomy_term');
     $this->installEntitySchema('comment');
-    $this->installSchema('file', ['file_usage']);
-    $this->installSchema('filelink_usage', [
-      'filelink_usage_matches',
-      'filelink_usage_scan_status',
-    ]);
-    $this->installSchema('node', ['node_access']);
-    $this->installConfig(['system', 'node', 'filter']);
-
-    $node_type = NodeType::create([
-      'type' => 'article',
-      'name' => 'Article',
-    ]);
-    $node_type->save();
-    node_add_body_field($node_type);
   }
 
   /**

--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -2,17 +2,16 @@
 
 namespace Drupal\Tests\filelink_usage\Kernel;
 
-use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase;
 use Drupal\file\Entity\File;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 
 /**
  * Tests reconciliation of file usage entries.
  *
  * @group filelink_usage
  */
-class FileLinkUsageReconcileTest extends KernelTestBase {
+class FileLinkUsageReconcileTest extends FileLinkUsageKernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -31,28 +30,6 @@ class FileLinkUsageReconcileTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp(): void {
-    parent::setUp();
-
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('file');
-    $this->installEntitySchema('node');
-    $this->installSchema('file', ['file_usage']);
-    $this->installSchema('filelink_usage', [
-      'filelink_usage_matches',
-      'filelink_usage_scan_status',
-    ]);
-    $this->installSchema('node', ['node_access']);
-    $this->installConfig(['system', 'node', 'filter']);
-
-    $node_type = NodeType::create([
-      'type' => 'article',
-      'name' => 'Article',
-    ]);
-    $node_type->save();
-    node_add_body_field($node_type);
-  }
-
   /**
    * Stale usages are removed and missing ones restored.
    */

--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -2,17 +2,16 @@
 
 namespace Drupal\Tests\filelink_usage\Kernel;
 
-use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase;
 use Drupal\file\Entity\File;
 use Drupal\node\Entity\Node;
-use Drupal\node\Entity\NodeType;
 
 /**
  * Ensures file usage entries are not duplicated when scanning.
  *
  * @group filelink_usage
  */
-class FileLinkUsageScannerTest extends KernelTestBase {
+class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -33,24 +32,6 @@ class FileLinkUsageScannerTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('file');
-    $this->installEntitySchema('node');
-    $this->installSchema('file', ['file_usage']);
-    $this->installSchema('filelink_usage', [
-      'filelink_usage_matches',
-      'filelink_usage_scan_status',
-    ]);
-    $this->installSchema('node', ['node_access']);
-    $this->installConfig(['system', 'node', 'filter']);
-
-    $node_type = NodeType::create([
-      'type' => 'article',
-      'name' => 'Article',
-    ]);
-    $node_type->save();
-    node_add_body_field($node_type);
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `FileLinkUsageKernelTestBase` with common setup logic
- update all kernel tests to extend the new base class
- remove duplicate setup code in individual tests

## Testing
- `php -l tests/src/Kernel/FileLinkUsageKernelTestBase.php`
- `phpunit tests/src/Kernel/FileLinkUsageScannerTest.php` *(fails: Class not found)*

------
https://chatgpt.com/codex/tasks/task_e_687368a71744833188daa62db4f881b0