### PR TITLE
Replace deprecated renderPlain call

### DIFF
--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -108,7 +108,8 @@ class FileLinkUsageScanner {
 
     // 1. Render the entity and find all file URLs in its HTML.
     $view_builder = $this->entityTypeManager->getViewBuilder($entity_type);
-    $html = (string) $this->renderer->renderPlain($view_builder->view($entity, 'full'));
+    $build = $view_builder->view($entity, 'full');
+    $html = (string) $this->renderer->renderInIsolation($build);
     preg_match_all('/(?:src|href)="([^"]*\\/(?:sites\\/default\\/files|system\\/files)\\/[^"]+)"/i', $html, $matches);
     $file_urls = $matches[1] ?? [];
 


### PR DESCRIPTION
## Summary
- adjust scanner to use `renderInIsolation()` instead of deprecated `renderPlain()`

## Testing
- `php -l src/FileLinkUsageScanner.php`
- `phpunit tests/src/Kernel/FileLinkUsageScannerTest.php` *(fails: Class "Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873718ba3b88331b81b3c046318b872