### PR TITLE
Fix scanning hooks and link normalization

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -29,16 +29,14 @@ function filelink_usage_entity_insert(EntityInterface $entity): void {
 
   switch ($entity->getEntityTypeId()) {
     case 'file':
-      // Just invalidate the new file’s cache‑tag so “Used In” shows 0 instantly.
       /** @var \Drupal\file\FileInterface $entity */
       $manager->addUsageForFile($entity);
       break;
 
     default:
-      // Newly created content may contain hard‑coded links – rescan next cron.
       $entity_type = $entity->getEntityType();
       if ($entity_type instanceof ContentEntityTypeInterface) {
-        $manager->markEntityForScan($entity->getEntityTypeId(), $entity->id());
+        \Drupal::service('filelink_usage.scanner')->scanEntity($entity);
       }
   }
 }
@@ -47,11 +45,9 @@ function filelink_usage_entity_insert(EntityInterface $entity): void {
  * Implements hook_entity_update().
  */
 function filelink_usage_entity_update(EntityInterface $entity): void {
-  // Any content edit might add/remove links – mark for re‑scan.
   $entity_type = $entity->getEntityType();
   if ($entity_type instanceof ContentEntityTypeInterface) {
-    \Drupal::service('filelink_usage.manager')
-      ->markEntityForScan($entity->getEntityTypeId(), $entity->id());
+    \Drupal::service('filelink_usage.scanner')->scanEntity($entity);
   }
 }
 

--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -21,6 +21,7 @@ services:
       - '@config.factory'
       - '@datetime.time'
       - '@logger.channel.filelink_usage'
+      - '@filelink_usage.normalizer'
 
   filelink_usage.normalizer:
     class: Drupal\filelink_usage\FileLinkUsageNormalizer

--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -64,6 +64,13 @@ class FileLinkUsageManager {
    * appears immediately with “0”.
    */
   public function addUsageForFile(FileInterface $file): void {
+    $uri = $file->getFileUri();
+    $query = $this->database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['entity_type', 'entity_id'])
+      ->condition('link', $uri);
+    foreach ($query->execute() as $row) {
+      $this->fileUsage->add($file, 'filelink_usage', $row->entity_type, (int) $row->entity_id);
+    }
     \Drupal::service('cache_tags.invalidator')->invalidateTags(['file:' . $file->id()]);
   }
 
@@ -152,6 +159,13 @@ class FileLinkUsageManager {
    */
   public function cleanupNode(NodeInterface $node): void {
     $this->reconcileEntityUsage('node', $node->id(), TRUE);
+  }
+
+  /**
+   * Convenience wrapper to reconcile usage for a node.
+   */
+  public function reconcileNodeUsage(int $nid): void {
+    $this->reconcileEntityUsage('node', $nid, FALSE);
   }
 
   /**

--- a/src/FileLinkUsageNormalizer.php
+++ b/src/FileLinkUsageNormalizer.php
@@ -10,9 +10,25 @@ namespace Drupal\filelink_usage;
 class FileLinkUsageNormalizer {
 
   /**
-   * Return the URI unchanged for now.
+   * Normalize a raw file URL or path to a Drupal stream wrapper URI.
    */
   public function normalize(string $uri): string {
+    // Strip scheme and host if present.
+    $uri = preg_replace('#^https?://[^/]+#', '', $uri);
+    // Remove query strings or fragments.
+    $uri = preg_replace('#[?#].*$#', '', $uri);
+    // Collapse duplicate slashes.
+    $uri = preg_replace('#/+#', '/', $uri);
+    // Decode percent encoded characters.
+    $uri = rawurldecode($uri);
+
+    if (str_contains($uri, '/sites/default/files/')) {
+      $uri = 'public://' . ltrim(explode('/sites/default/files/', $uri, 2)[1], '/');
+    }
+    elseif (str_contains($uri, '/system/files/')) {
+      $uri = 'private://' . ltrim(explode('/system/files/', $uri, 2)[1], '/');
+    }
+
     return $uri;
   }
 

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -96,7 +96,7 @@ class SettingsForm extends ConfigFormBase {
   /**
    * Purges saved file link matches from the database.
    */
-  public function purgeFileLinkMatches(array &$form, FormStateInterface $form_state): void {
+  public function purgeFileLinkMatches(array $form, FormStateInterface $form_state): void {
     $connection = Drupal::database();
     $connection->truncate('filelink_usage_matches')->execute();
     \Drupal::service('filelink_usage.manager')->markAllForRescan();


### PR DESCRIPTION
## Summary
- scan entities immediately on insert/update
- record unmatched links and reconcile usage for new files
- normalize file link paths
- update services and settings

## Testing
- `php -l src/FileLinkUsageScanner.php`
- `php -l src/FileLinkUsageManager.php`
- `php -l filelink_usage.module`
- `php -l src/Form/SettingsForm.php`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687378da6c9c8331b19b2efb93cad7ab