### PR TITLE
Add cache tag invalidation test

### DIFF
--- a/tests/src/Kernel/FileLinkUsageCacheTagsTest.php
+++ b/tests/src/Kernel/FileLinkUsageCacheTagsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+
+/**
+ * Tests cache tag invalidation when scanning and cleaning up file links.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageCacheTagsTest extends FileLinkUsageKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'filelink_usage',
+  ];
+
+  /**
+   * Records invalidated cache tags.
+   */
+  protected array $invalidated = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->invalidated = [];
+    $invalidator = new class($this) {
+      private $test;
+      public function __construct($test) { $this->test = $test; }
+      public function invalidateTags(array $tags): void {
+        $this->test->invalidated = array_merge($this->test->invalidated, $tags);
+      }
+    };
+    $this->container->set('cache_tags.invalidator', $invalidator);
+  }
+
+  /**
+   * Scanning a node invalidates cache tags for newly found files.
+   */
+  public function testScanningInvalidatesTags(): void {
+    $uri = 'public://cache_invalidate.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'txt');
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'cache_invalidate.txt',
+    ]);
+    $file->save();
+
+    $body = '<a href="/sites/default/files/cache_invalidate.txt">Download</a>';
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Invalidate',
+      'body' => [
+        'value' => $body,
+        'format' => 'plain_text',
+      ],
+    ]);
+    $node->save();
+
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
+    $this->assertContains('file:' . $file->id(), $this->invalidated);
+  }
+
+  /**
+   * Removing file usage invalidates cache tags for the removed file.
+   */
+  public function testCleanupInvalidatesTags(): void {
+    $uri = 'public://cleanup_cache.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'txt');
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'cleanup_cache.txt',
+    ]);
+    $file->save();
+
+    $body = '<a href="/sites/default/files/cleanup_cache.txt">Download</a>';
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Cleanup',
+      'body' => [
+        'value' => $body,
+        'format' => 'plain_text',
+      ],
+    ]);
+    $node->save();
+
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
+    $this->invalidated = [];
+
+    $this->container->get('filelink_usage.manager')->cleanupNode($node);
+    $this->assertContains('file:' . $file->id(), $this->invalidated);
+  }
+
+}


### PR DESCRIPTION
## Summary
- add a new kernel test to verify cache tag invalidation when scanning and cleaning up file links

## Testing
- `./vendor/bin/phpunit tests/src/Kernel/FileLinkUsageCacheTagsTest.php --testdox --colors=never` *(fails: Class "Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737c10969c8331bc8962457f48b4e0