### PR TITLE
Fix scanning hooks and normalize file URIs

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -26,6 +26,7 @@ function filelink_usage_cron(): void {
  */
 function filelink_usage_entity_insert(EntityInterface $entity): void {
   $manager = \Drupal::service('filelink_usage.manager');
+  $scanner = \Drupal::service('filelink_usage.scanner');
 
   switch ($entity->getEntityTypeId()) {
     case 'file':
@@ -35,10 +36,10 @@ function filelink_usage_entity_insert(EntityInterface $entity): void {
       break;
 
     default:
-      // Newly created content may contain hard‑coded links – rescan next cron.
+      // Newly created content may contain hard‑coded links – scan immediately.
       $entity_type = $entity->getEntityType();
       if ($entity_type instanceof ContentEntityTypeInterface) {
-        $manager->markEntityForScan($entity->getEntityTypeId(), $entity->id());
+        $scanner->scanEntity($entity);
       }
   }
 }
@@ -47,11 +48,10 @@ function filelink_usage_entity_insert(EntityInterface $entity): void {
  * Implements hook_entity_update().
  */
 function filelink_usage_entity_update(EntityInterface $entity): void {
-  // Any content edit might add/remove links – mark for re‑scan.
+  // Any content edit might add/remove links – scan immediately.
   $entity_type = $entity->getEntityType();
   if ($entity_type instanceof ContentEntityTypeInterface) {
-    \Drupal::service('filelink_usage.manager')
-      ->markEntityForScan($entity->getEntityTypeId(), $entity->id());
+    \Drupal::service('filelink_usage.scanner')->scanEntity($entity);
   }
 }
 

--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -21,6 +21,7 @@ services:
       - '@config.factory'
       - '@datetime.time'
       - '@logger.channel.filelink_usage'
+      - '@filelink_usage.normalizer'
 
   filelink_usage.normalizer:
     class: Drupal\filelink_usage\FileLinkUsageNormalizer

--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -155,6 +155,13 @@ class FileLinkUsageManager {
   }
 
   /**
+   * Reconcile usage for a specific node ID.
+   */
+  public function reconcileNodeUsage(int $nid): void {
+    $this->reconcileEntityUsage('node', $nid);
+  }
+
+  /**
    * Remove usage records for a deleted file.
    */
   public function removeFileUsage(FileInterface $file): void {

--- a/src/FileLinkUsageNormalizer.php
+++ b/src/FileLinkUsageNormalizer.php
@@ -5,15 +5,22 @@ declare(strict_types=1);
 namespace Drupal\filelink_usage;
 
 /**
- * No‑op normalizer (placeholder for future logic).
+ * Normalizes file URIs for consistent comparison.
  */
 class FileLinkUsageNormalizer {
 
   /**
-   * Return the URI unchanged for now.
+   * Normalize a file URI by decoding and trimming extra parts.
    */
   public function normalize(string $uri): string {
-    return $uri;
+    [$scheme, $path] = explode('://', $uri, 2);
+    // Remove query strings and fragments.
+    $path = preg_replace('/[?#].*/', '', $path);
+    // Collapse duplicate slashes.
+    $path = preg_replace('#/{2,}#', '/', $path);
+    // Decode percent-encoded characters.
+    $path = rawurldecode($path);
+    return $scheme . '://' . $path;
   }
 
 }

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -27,8 +27,9 @@ class FileLinkUsageScanner {
   protected ConfigFactoryInterface $configFactory;
   protected TimeInterface $time;
   protected LoggerChannelInterface $logger;
+  protected FileLinkUsageNormalizer $normalizer;
 
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, RendererInterface $renderer, Connection $database, FileUsageInterface $fileUsage, ConfigFactoryInterface $configFactory, TimeInterface $time, LoggerChannelInterface $logger) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, RendererInterface $renderer, Connection $database, FileUsageInterface $fileUsage, ConfigFactoryInterface $configFactory, TimeInterface $time, LoggerChannelInterface $logger, FileLinkUsageNormalizer $normalizer) {
     $this->entityTypeManager = $entityTypeManager;
     $this->renderer = $renderer;
     $this->database = $database;
@@ -36,6 +37,7 @@ class FileLinkUsageScanner {
     $this->configFactory = $configFactory;
     $this->time = $time;
     $this->logger = $logger;
+    $this->normalizer = $normalizer;
   }
 
   /**
@@ -140,6 +142,9 @@ class FileLinkUsageScanner {
       else {
         continue;
       }
+
+      // Normalize the URI (remove query strings, duplicate slashes, decoding etc.).
+      $file_uri = $this->normalizer->normalize($file_uri);
       // Check if there is a managed File entity for this URI.
       $fid = NULL;
       $files = $this->entityTypeManager->getStorage('file')->loadByProperties(['uri' => $file_uri]);

--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -79,7 +79,8 @@ class FileLinkUsagePurgeTest extends FileLinkUsageKernelTestBase {
     // Call the purge handler.
     $form = SettingsForm::create($this->container);
     $form_state = new FormState();
-    $form->purgeFileLinkMatches([], $form_state);
+    $form_array = [];
+    $form->purgeFileLinkMatches($form_array, $form_state);
 
     $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();
     $this->assertEquals(0, $count);
@@ -159,7 +160,8 @@ class FileLinkUsagePurgeTest extends FileLinkUsageKernelTestBase {
 
     $form = SettingsForm::create($this->container);
     $form_state = new FormState();
-    $form->purgeFileLinkMatches([], $form_state);
+    $form_array = [];
+    $form->purgeFileLinkMatches($form_array, $form_state);
 
     $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();
     $this->assertEquals(0, $count);


### PR DESCRIPTION
## Summary
- trigger scanning immediately on entity save
- normalize file URIs when detecting links
- provide a `reconcileNodeUsage()` helper
- ensure purge form callback works with PHP strict mode

## Testing
- `phpunit --version`
- `phpunit -c phpunit.xml tests/src/Kernel --group filelink_usage` *(fails: Could not read `phpunit.xml`)*

------
https://chatgpt.com/codex/tasks/task_e_687378da6c9c8331b19b2efb93cad7ab