### PR TITLE
Add taxonomy term and comment kernel tests

### DIFF
--- a/tests/src/Kernel/FileLinkUsageCommentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageCommentHooksTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\comment\Entity\Comment;
+use Drupal\node\Entity\Node;
+
+/**
+ * Tests scanning comment bodies for file links.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageCommentHooksTest extends FileLinkUsageKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'comment',
+    'filelink_usage',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('comment');
+    $this->installConfig(['comment']);
+  }
+
+  /**
+   * Ensures comment bodies with links create usage records.
+   */
+  public function testCommentScanRecordsUsage(): void {
+    $uri = 'public://comment_link.txt';
+    file_put_contents(
+      $this->container->get('file_system')->realpath($uri),
+      'txt'
+    );
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'comment_link.txt',
+    ]);
+    $file->save();
+
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Comment parent',
+      'body' => [
+        'value' => 'Parent node',
+        'format' => 'plain_text',
+      ],
+    ]);
+    $node->save();
+
+    $comment = Comment::create([
+      'comment_type' => 'comment',
+      'entity_type' => 'node',
+      'field_name' => 'comment',
+      'entity_id' => $node->id(),
+      'comment_body' => [
+        'value' => '<a href="/sites/default/files/comment_link.txt">Download</a>',
+        'format' => 'plain_text',
+      ],
+    ]);
+    $comment->save();
+
+    // Scan the comment to register the link.
+    $this->container->get('filelink_usage.scanner')->scan([
+      'comment' => [$comment->id()],
+    ]);
+
+    $database = $this->container->get('database');
+    $link = $database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('entity_type', 'comment')
+      ->condition('entity_id', $comment->id())
+      ->execute()
+      ->fetchField();
+    $this->assertEquals($uri, $link);
+
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertArrayHasKey($comment->id(), $usage['filelink_usage']['comment']);
+  }
+
+}

--- a/tests/src/Kernel/FileLinkUsageTermHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageTermHooksTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Tests scanning taxonomy term descriptions for file links.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageTermHooksTest extends FileLinkUsageKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'taxonomy',
+    'filelink_usage',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('taxonomy_term');
+    $this->installConfig(['taxonomy']);
+
+    Vocabulary::create([
+      'vid' => 'tags',
+      'name' => 'Tags',
+    ])->save();
+  }
+
+  /**
+   * Ensures term descriptions with links create usage records.
+   */
+  public function testTermScanRecordsUsage(): void {
+    $uri = 'public://term_link.txt';
+    file_put_contents(
+      $this->container->get('file_system')->realpath($uri),
+      'txt'
+    );
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'term_link.txt',
+    ]);
+    $file->save();
+
+    $term = Term::create([
+      'vid' => 'tags',
+      'name' => 'Term with link',
+      'description' => [
+        'value' => '<a href="/sites/default/files/term_link.txt">Download</a>',
+        'format' => 'plain_text',
+      ],
+    ]);
+    $term->save();
+
+    // Scan the term to register the link.
+    $this->container->get('filelink_usage.scanner')->scan([
+      'taxonomy_term' => [$term->id()],
+    ]);
+
+    $database = $this->container->get('database');
+    $link = $database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('entity_type', 'taxonomy_term')
+      ->condition('entity_id', $term->id())
+      ->execute()
+      ->fetchField();
+    $this->assertEquals($uri, $link);
+
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertArrayHasKey($term->id(), $usage['filelink_usage']['taxonomy_term']);
+  }
+
+}


### PR DESCRIPTION
## Summary
- add `FileLinkUsageTermHooksTest` covering taxonomy terms
- add `FileLinkUsageCommentHooksTest` covering comments

## Testing
- `phpunit tests/src/Kernel/FileLinkUsageTermHooksTest.php` *(fails: class not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737c0fc9a88331ad63462ec2417da4