### PR TITLE
Add method for recording invalidated tags

### DIFF
--- a/tests/src/Kernel/FileLinkUsageCacheTagsTest.php
+++ b/tests/src/Kernel/FileLinkUsageCacheTagsTest.php
@@ -32,6 +32,13 @@ class FileLinkUsageCacheTagsTest extends FileLinkUsageKernelTestBase {
   protected array $invalidated = [];
 
   /**
+   * Records invalidated cache tags.
+   */
+  public function recordInvalidatedTags(array $tags): void {
+    $this->invalidated = array_merge($this->invalidated, $tags);
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -42,7 +49,7 @@ class FileLinkUsageCacheTagsTest extends FileLinkUsageKernelTestBase {
       private $test;
       public function __construct($test) { $this->test = $test; }
       public function invalidateTags(array $tags): void {
-        $this->test->invalidated = array_merge($this->test->invalidated, $tags);
+        $this->test->recordInvalidatedTags($tags);
       }
     };
     $this->container->set('cache_tags.invalidator', $invalidator);


### PR DESCRIPTION
## Summary
- add new method `recordInvalidatedTags()` to FileLinkUsageCacheTagsTest
- use the new method in the anonymous invalidator

## Testing
- `composer install`
- `phpunit tests/src/Kernel/FileLinkUsageCacheTagsTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68739141d8a48331a165b7a07eb467b7