### PR TITLE
Fix comment setup in tests

### DIFF
--- a/tests/src/Kernel/FileLinkUsageCommentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageCommentHooksTest.php
@@ -36,6 +36,7 @@ class FileLinkUsageCommentHooksTest extends FileLinkUsageKernelTestBase {
 
     $this->installEntitySchema('comment');
     $this->installConfig(['comment']);
+    comment_add_default_field('node', 'article');
   }
 
   /**


### PR DESCRIPTION
## Summary
- ensure comments render correctly by adding default field setup in `FileLinkUsageCommentHooksTest`

## Testing
- `phpunit -c core modules/custom/filelink_usage/tests/src/Kernel` *(fails: Cannot open file)*

------
https://chatgpt.com/codex/tasks/task_e_687391fce3c88331b5b7086b491f2dcd