### PR TITLE
Fix FileLinkUsageScannerTest comment default field

### DIFF
--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -39,7 +39,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
     parent::setUp();
     $this->installEntitySchema('taxonomy_term');
     $this->installEntitySchema('comment');
-    comment_add_default_field('node', 'article');
+    \comment_add_default_field('node', 'article');
   }
 
   /**


### PR DESCRIPTION
## Summary
- ensure `comment_add_default_field` uses the global namespace in `FileLinkUsageScannerTest`

## Testing
- `php -l tests/src/Kernel/FileLinkUsageScannerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_687392f4f9a88331a6a619777f827b58