### PR TITLE
Fix term hooks test dependencies

### DIFF
--- a/tests/src/Kernel/FileLinkUsageTermHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageTermHooksTest.php
@@ -23,6 +23,7 @@ class FileLinkUsageTermHooksTest extends FileLinkUsageKernelTestBase {
     'filter',
     'text',
     'file',
+    'node',
     'taxonomy',
     'filelink_usage',
   ];


### PR DESCRIPTION
## Summary
- ensure node schemas install for term hook tests

## Testing
- `php -l tests/src/Kernel/FileLinkUsageTermHooksTest.php`

------
https://chatgpt.com/codex/tasks/task_e_687393e1c8b48331971b0c2d47534244