### PR TITLE
Fix tests using purgeFileLinkMatches

### DIFF
--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -79,7 +79,8 @@ class FileLinkUsagePurgeTest extends FileLinkUsageKernelTestBase {
     // Call the purge handler.
     $form = SettingsForm::create($this->container);
     $form_state = new FormState();
-    $form->purgeFileLinkMatches([], $form_state);
+    $form_array = [];
+    $form->purgeFileLinkMatches($form_array, $form_state);
 
     $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();
     $this->assertEquals(0, $count);
@@ -159,7 +160,8 @@ class FileLinkUsagePurgeTest extends FileLinkUsageKernelTestBase {
 
     $form = SettingsForm::create($this->container);
     $form_state = new FormState();
-    $form->purgeFileLinkMatches([], $form_state);
+    $form_array = [];
+    $form->purgeFileLinkMatches($form_array, $form_state);
 
     $count = $database->select('filelink_usage_matches')->countQuery()->execute()->fetchField();
     $this->assertEquals(0, $count);


### PR DESCRIPTION
## Summary
- pass a variable by reference when purging matches in tests

## Testing
- `composer validate --no-check-all`
- `php -l tests/src/Kernel/FileLinkUsagePurgeTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6873956a90788331a8ef024f19736f09