### PR TITLE
Fix reconcile test usage call

### DIFF
--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -89,7 +89,8 @@ class FileLinkUsageReconcileTest extends FileLinkUsageKernelTestBase {
       ->execute();
 
     // Reconcile should restore usage for file1 and remove from file2.
-    $this->container->get('filelink_usage.manager')->reconcileNodeUsage($node->id());
+    $this->container->get('filelink_usage.manager')
+      ->reconcileEntityUsage('node', $node->id());
 
     $usage1 = $this->container->get('file.usage')->listUsage($file1);
     $this->assertArrayHasKey($node->id(), $usage1['filelink_usage']['node']);


### PR DESCRIPTION
## Summary
- update test to use reconcileEntityUsage instead of obsolete method

## Testing
- `php -l tests/src/Kernel/FileLinkUsageReconcileTest.php`
- `composer validate --no-check-all --strict`

------
https://chatgpt.com/codex/tasks/task_e_68739624855483319578cd24dff79925