### PR TITLE
Use basic_html in tests

### DIFF
--- a/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
@@ -60,7 +60,7 @@ class FileLinkUsageBlockContentHooksTest extends FileLinkUsageKernelTestBase {
       'info' => 'Hook insert',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $block->save();

--- a/tests/src/Kernel/FileLinkUsageCacheTagsTest.php
+++ b/tests/src/Kernel/FileLinkUsageCacheTagsTest.php
@@ -73,7 +73,7 @@ class FileLinkUsageCacheTagsTest extends FileLinkUsageKernelTestBase {
       'title' => 'Invalidate',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -100,7 +100,7 @@ class FileLinkUsageCacheTagsTest extends FileLinkUsageKernelTestBase {
       'title' => 'Cleanup',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();

--- a/tests/src/Kernel/FileLinkUsageCleanupTest.php
+++ b/tests/src/Kernel/FileLinkUsageCleanupTest.php
@@ -46,7 +46,7 @@ class FileLinkUsageCleanupTest extends FileLinkUsageKernelTestBase {
       'title' => 'Cleanup node',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();

--- a/tests/src/Kernel/FileLinkUsageCommentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageCommentHooksTest.php
@@ -59,7 +59,7 @@ class FileLinkUsageCommentHooksTest extends FileLinkUsageKernelTestBase {
       'title' => 'Comment parent',
       'body' => [
         'value' => 'Parent node',
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -71,7 +71,7 @@ class FileLinkUsageCommentHooksTest extends FileLinkUsageKernelTestBase {
       'entity_id' => $node->id(),
       'comment_body' => [
         'value' => '<a href="/sites/default/files/comment_link.txt">Download</a>',
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $comment->save();

--- a/tests/src/Kernel/FileLinkUsageFileHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileHooksTest.php
@@ -42,7 +42,7 @@ class FileLinkUsageFileHooksTest extends FileLinkUsageKernelTestBase {
       'title' => 'File hook',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();

--- a/tests/src/Kernel/FileLinkUsageKernelTestBase.php
+++ b/tests/src/Kernel/FileLinkUsageKernelTestBase.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\filelink_usage\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\NodeType;
+use Drupal\filter\Entity\FilterFormat;
 
 /**
  * Provides common setup for filelink_usage kernel tests.
@@ -26,6 +27,13 @@ abstract class FileLinkUsageKernelTestBase extends KernelTestBase {
     ]);
     $this->installSchema('node', ['node_access']);
     $this->installConfig(['system', 'node', 'filter']);
+
+    if (!FilterFormat::load('basic_html')) {
+      FilterFormat::create([
+        'format' => 'basic_html',
+        'name' => 'Basic HTML',
+      ])->save();
+    }
 
     $node_type = NodeType::create([
       'type' => 'article',

--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -48,7 +48,7 @@ class FileLinkUsageNodeHooksTest extends FileLinkUsageKernelTestBase {
       'title' => 'Hook insert',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -82,7 +82,7 @@ class FileLinkUsageNodeHooksTest extends FileLinkUsageKernelTestBase {
       'title' => 'Hook update',
       'body' => [
         'value' => 'Initial body',
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -96,7 +96,7 @@ class FileLinkUsageNodeHooksTest extends FileLinkUsageKernelTestBase {
 
     $node->set('body', [
       'value' => '<a href="/sites/default/files/hook_update.txt">Download</a>',
-      'format' => 'plain_text',
+      'format' => 'basic_html',
     ]);
     $node->save();
 
@@ -137,7 +137,7 @@ class FileLinkUsageNodeHooksTest extends FileLinkUsageKernelTestBase {
       'title' => 'Replace usage',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -149,7 +149,7 @@ class FileLinkUsageNodeHooksTest extends FileLinkUsageKernelTestBase {
     // Update to link to the second file.
     $node->set('body', [
       'value' => '<a href="/sites/default/files/hook_replace2.txt">Download</a>',
-      'format' => 'plain_text',
+      'format' => 'basic_html',
     ]);
     $node->save();
 
@@ -177,7 +177,7 @@ class FileLinkUsageNodeHooksTest extends FileLinkUsageKernelTestBase {
       'title' => 'Hook delete',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();

--- a/tests/src/Kernel/FileLinkUsagePrivateFileTest.php
+++ b/tests/src/Kernel/FileLinkUsagePrivateFileTest.php
@@ -77,7 +77,7 @@ class FileLinkUsagePrivateFileTest extends FileLinkUsageKernelTestBase {
       'title' => 'Private file',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();

--- a/tests/src/Kernel/FileLinkUsagePurgeTest.php
+++ b/tests/src/Kernel/FileLinkUsagePurgeTest.php
@@ -62,7 +62,7 @@ class FileLinkUsagePurgeTest extends FileLinkUsageKernelTestBase {
       'title' => 'Test node',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -113,7 +113,7 @@ class FileLinkUsagePurgeTest extends FileLinkUsageKernelTestBase {
       'title' => 'Test node 2',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -149,7 +149,7 @@ class FileLinkUsagePurgeTest extends FileLinkUsageKernelTestBase {
       'title' => 'Cron repopulate',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();

--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -62,7 +62,7 @@ class FileLinkUsageReconcileTest extends FileLinkUsageKernelTestBase {
       'title' => 'Reconcile',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();

--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -62,7 +62,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
       'title' => 'Test node',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -99,7 +99,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
       'title' => 'Test node',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -147,7 +147,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
       'title' => 'Test node spaces',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -191,7 +191,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
       'body' => [
         'value' => 'No link here',
         'summary' => '<a href="/sites/default/files/summary.txt">Download</a>',
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -228,7 +228,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
       'title' => 'Repopulate',
       'body' => [
         'value' => $body,
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -275,7 +275,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
       'vid' => 'tags',
       'description' => [
         'value' => '<a href="/sites/default/files/term.txt">Download</a>',
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $term->save();
@@ -311,7 +311,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
       'title' => 'Node with comment',
       'body' => [
         'value' => 'Body',
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $node->save();
@@ -325,7 +325,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
       'subject' => 'Test comment',
       'comment_body' => [
         'value' => '<a href="/sites/default/files/comment.txt">Download</a>',
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $comment->save();

--- a/tests/src/Kernel/FileLinkUsageTermHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageTermHooksTest.php
@@ -63,7 +63,7 @@ class FileLinkUsageTermHooksTest extends FileLinkUsageKernelTestBase {
       'name' => 'Term with link',
       'description' => [
         'value' => '<a href="/sites/default/files/term_link.txt">Download</a>',
-        'format' => 'plain_text',
+        'format' => 'basic_html',
       ],
     ]);
     $term->save();


### PR DESCRIPTION
## Summary
- ensure `basic_html` format exists in test setup
- update tests to use `basic_html` for fields containing file links

## Testing
- `php -l` on all modified test files
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873971ec31c8331b2f36303c2530ec1