### PR TITLE
Implement CacheTagsInvalidatorInterface in test

### DIFF
--- a/tests/src/Kernel/FileLinkUsageCacheTagsTest.php
+++ b/tests/src/Kernel/FileLinkUsageCacheTagsTest.php
@@ -45,11 +45,19 @@ class FileLinkUsageCacheTagsTest extends FileLinkUsageKernelTestBase {
     parent::setUp();
 
     $this->invalidated = [];
-    $invalidator = new class($this) {
+    $invalidator = new class($this) implements \Drupal\Core\Cache\CacheTagsInvalidatorInterface {
       private $test;
-      public function __construct($test) { $this->test = $test; }
+
+      public function __construct($test) {
+        $this->test = $test;
+      }
+
       public function invalidateTags(array $tags): void {
         $this->test->recordInvalidatedTags($tags);
+      }
+
+      public function invalidateTagsAsynchronously(array $tags): void {
+        $this->invalidateTags($tags);
       }
     };
     $this->container->set('cache_tags.invalidator', $invalidator);


### PR DESCRIPTION
## Summary
- implement CacheTagsInvalidatorInterface on the anonymous cache tag invalidator in FileLinkUsageCacheTagsTest
- add required methods for invalidateTags and invalidateTagsAsynchronously

## Testing
- `composer install`
- `phpunit -c core` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873bffff4d883319671ee3b82306b8f