### PR TITLE
Use comment manager service for default field

### DIFF
--- a/tests/src/Kernel/FileLinkUsageCommentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageCommentHooksTest.php
@@ -36,7 +36,7 @@ class FileLinkUsageCommentHooksTest extends FileLinkUsageKernelTestBase {
 
     $this->installEntitySchema('comment');
     $this->installConfig(['comment']);
-    comment_add_default_field('node', 'article');
+    \Drupal::service('comment.manager')->addDefaultField('node', 'article');
   }
 
   /**

--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -39,7 +39,7 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
     parent::setUp();
     $this->installEntitySchema('taxonomy_term');
     $this->installEntitySchema('comment');
-    \comment_add_default_field('node', 'article');
+    \Drupal::service('comment.manager')->addDefaultField('node', 'article');
   }
 
   /**


### PR DESCRIPTION
## Summary
- use Drupal's comment.manager service when adding default comment fields in tests

## Testing
- `php -l tests/src/Kernel/FileLinkUsageCommentHooksTest.php`
- `php -l tests/src/Kernel/FileLinkUsageScannerTest.php`
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_6873c0014ff883319f8b58522e4c4eab