### PR TITLE
Fix file hook test usage count query

### DIFF
--- a/tests/src/Kernel/FileLinkUsageFileHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileHooksTest.php
@@ -57,8 +57,8 @@ class FileLinkUsageFileHooksTest extends FileLinkUsageKernelTestBase {
     $this->assertEquals(0, $count);
 
     $usage_count = $database->select('file_usage', 'fu')
-      ->countQuery()
       ->condition('id', $node->id())
+      ->countQuery()
       ->execute()
       ->fetchField();
     $this->assertEquals(0, $usage_count);


### PR DESCRIPTION
## Summary
- fix order of condition and countQuery in FileLinkUsageFileHooksTest

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873c003f54483319771fe654b4de71f