### PR TITLE
Fix scanner call in FileLinkUsageNodeHooksTest

### DIFF
--- a/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageNodeHooksTest.php
@@ -147,6 +147,8 @@ class FileLinkUsageNodeHooksTest extends FileLinkUsageKernelTestBase {
       ],
     ]);
     $node->save();
+    $this->container->get('filelink_usage.scanner')
+      ->scan(['node' => [$node->id()]]);
 
     // Usage should reference the first file.
     $usage1 = $this->container->get('file.usage')->listUsage($file1);


### PR DESCRIPTION
## Summary
- register node usage before assertions in update replace usage test

## Testing
- `phpunit -c core modules/custom/filelink_usage/tests/src/Kernel` *(fails: Cannot open file)*

------
https://chatgpt.com/codex/tasks/task_e_6873c005389c8331999a21788148327e