### PR TITLE
Fix private file setup in kernel test

### DIFF
--- a/tests/src/Kernel/FileLinkUsagePrivateFileTest.php
+++ b/tests/src/Kernel/FileLinkUsagePrivateFileTest.php
@@ -46,9 +46,7 @@ class FileLinkUsagePrivateFileTest extends FileLinkUsageKernelTestBase {
     }
 
     // Configure Drupal to use this directory for the private file system.
-    $this->config('system.file')
-      ->set('path.private', $this->privateDirectory)
-      ->save();
+    \Drupal::service('settings')->set('file_private_path', $this->privateDirectory);
   }
 
   /**


### PR DESCRIPTION
## Summary
- update FileLinkUsagePrivateFileTest to use settings service

## Testing
- `php -l tests/src/Kernel/FileLinkUsagePrivateFileTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6873c005e0e08331bbcf22e97acbf408