### PR TITLE
Ensure reconciliation scan is applied in Kernel test

### DIFF
--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -91,6 +91,8 @@ class FileLinkUsageReconcileTest extends FileLinkUsageKernelTestBase {
     // Reconcile should restore usage for file1 and remove from file2.
     $this->container->get('filelink_usage.manager')
       ->reconcileEntityUsage('node', $node->id());
+    // Apply reconciliation immediately by rescanning the node.
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
 
     $usage1 = $this->container->get('file.usage')->listUsage($file1);
     $this->assertArrayHasKey($node->id(), $usage1['filelink_usage']['node']);


### PR DESCRIPTION
## Summary
- run the scanner after calling `reconcileEntityUsage()` in `FileLinkUsageReconcileTest`

## Testing
- `php -l tests/src/Kernel/FileLinkUsageReconcileTest.php`
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6873c007ec9083319bae7c2f34dc35bb