### PR TITLE
Adjust entity type for block hooks test

### DIFF
--- a/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
@@ -70,13 +70,13 @@ class FileLinkUsageBlockContentHooksTest extends FileLinkUsageKernelTestBase {
     $database = $this->container->get('database');
     $link = $database->select('filelink_usage_matches', 'f')
       ->fields('f', ['link'])
-      ->condition('entity_type', 'block_content')
+      ->condition('entity_type', 'block')
       ->condition('entity_id', $block->id())
       ->execute()
       ->fetchField();
     $this->assertEquals($uri, $link);
     $usage = $this->container->get('file.usage')->listUsage($file);
-    $this->assertArrayHasKey($block->id(), $usage['filelink_usage']['block_content']);
+    $this->assertArrayHasKey($block->id(), $usage['filelink_usage']['block']);
   }
 
 


### PR DESCRIPTION
## Summary
- ensure block content hook test checks for `block` entity type

## Testing
- `vendor/bin/phpunit -c core modules/custom/filelink_usage/tests/src/Kernel` *(fails: No such file or directory)*
- `drush phpunit -- modules/custom/filelink_usage/tests/src/Kernel` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c0090a848331903dcd298c8fba96