### PR TITLE
Fix purgeEntityUsage to remove scan status entries

### DIFF
--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -307,6 +307,19 @@ class FileLinkUsageManager {
         ->execute();
     }
 
+    // Remove scan status entry for this entity.
+    if ($this->statusHasEntityColumns) {
+      $this->database->delete('filelink_usage_scan_status')
+        ->condition('entity_type', $etype)
+        ->condition('entity_id', $eid)
+        ->execute();
+    }
+    elseif ($etype === 'node') {
+      $this->database->delete('filelink_usage_scan_status')
+        ->condition('nid', $eid)
+        ->execute();
+    }
+
     if ($file_ids) {
       $tags = array_map(fn(int $id) => "file:$id", array_unique($file_ids));
       \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);


### PR DESCRIPTION
## Summary
- ensure purgeEntityUsage removes matching rows from `filelink_usage_scan_status`

## Testing
- `composer install`
- `vendor/bin/phpunit -c core tests/src/Kernel` *(fails: Could not read "core")*

------
https://chatgpt.com/codex/tasks/task_e_6873c00a9c008331a0f1035fd5e37044