### PR TITLE
Remove redundant node rescan step

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -101,16 +101,6 @@ class SettingsForm extends ConfigFormBase {
     $connection->truncate('filelink_usage_matches')->execute();
     \Drupal::service('filelink_usage.manager')->markAllForRescan();
 
-    // Mark all nodes for rescan in case additional modules rely on this hook.
-    $storage = Drupal::entityTypeManager()->getStorage('node');
-    $nids = $storage->getQuery()->accessCheck(FALSE)->execute();
-    if ($nids) {
-      $nodes = $storage->loadMultiple($nids);
-      foreach ($nodes as $node) {
-        filelink_usage_mark_for_rescan($node);
-      }
-    }
-
     $this->configFactory->getEditable('filelink_usage.settings')
       ->set('last_scan', 0)
       ->save();


### PR DESCRIPTION
## Summary
- rely solely on `markAllForRescan()` when purging saved file links
- drop loop that loaded and marked every node for rescan

## Testing
- `php -l src/Form/SettingsForm.php`
- `composer install` *(generates no vendor dependencies)*
- `phpunit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c00baf308331821d56938e7a9638