### PR TITLE
Fix failing reconcile test

### DIFF
--- a/tests/src/Kernel/FileLinkUsageReconcileTest.php
+++ b/tests/src/Kernel/FileLinkUsageReconcileTest.php
@@ -70,6 +70,9 @@ class FileLinkUsageReconcileTest extends FileLinkUsageKernelTestBase {
     // Initial scan.
     $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
 
+    $usage_initial = $this->container->get('file.usage')->listUsage($file1);
+    $this->assertArrayHasKey($node->id(), $usage_initial['filelink_usage']['node']);
+
     $database = $this->container->get('database');
     // Remove usage for the real file and add usage for another file.
     $database->delete('file_usage')


### PR DESCRIPTION
## Summary
- ensure initial file usage exists before mutating usage

## Testing
- `composer install`
- `vendor/bin/phpunit -c core modules/custom/filelink_usage/tests/src/Kernel` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873cdfe18b083318e49a9313c8c90c9