### PR TITLE
Ensure block test adds body field

### DIFF
--- a/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php
@@ -39,7 +39,17 @@ class FileLinkUsageBlockContentHooksTest extends FileLinkUsageKernelTestBase {
     $this->installEntitySchema('block_content');
     $this->installConfig(['block_content']);
 
-    BlockContentType::create(['id' => 'basic', 'label' => 'Basic'])->save();
+    $block_type = BlockContentType::create(['id' => 'basic', 'label' => 'Basic']);
+    $block_type->save();
+    // Ensure the custom block type has a body field that is displayed in the
+    // "full" view mode so the scanner can detect file links within it.
+    block_content_add_body_field($block_type);
+    entity_get_display('block_content', 'basic', 'full')
+      ->setComponent('body', [
+        'label' => 'hidden',
+        'type' => 'text_default',
+      ])
+      ->save();
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a body field to the `basic` block type in `FileLinkUsageBlockContentHooksTest`
- enable the body field in the `full` view display

## Testing
- `vendor/bin/phpunit tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php --filter testInsertHookScansBlock` *(fails: Class "Drupal\Tests\filelink_usage\Kernel\FileLinkUsageKernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873cdfe5ce48331a3eb53320bc2ab0e