### PR TITLE
Update comment field setup in tests

### DIFF
--- a/tests/src/Kernel/FileLinkUsageScannerTest.php
+++ b/tests/src/Kernel/FileLinkUsageScannerTest.php
@@ -8,6 +8,10 @@ use Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\comment\Entity\Comment;
+use Drupal\comment\Entity\CommentType;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\comment\Plugin\Field\FieldType\CommentItemInterface;
 
 /**
  * Ensures file usage entries are not duplicated when scanning.
@@ -39,7 +43,51 @@ class FileLinkUsageScannerTest extends FileLinkUsageKernelTestBase {
     parent::setUp();
     $this->installEntitySchema('taxonomy_term');
     $this->installEntitySchema('comment');
-    \Drupal::service('comment.manager')->addDefaultField('node', 'article');
+
+    // Create a basic comment type for nodes.
+    CommentType::create([
+      'id' => 'comment',
+      'label' => 'Comment',
+      'target_entity_type_id' => 'node',
+    ])->save();
+    \Drupal::service('comment.manager')->addBodyField('comment');
+
+    // Attach the comment field to the article content type.
+    FieldStorageConfig::create([
+      'entity_type' => 'node',
+      'field_name' => 'comment',
+      'type' => 'comment',
+      'settings' => [
+        'comment_type' => 'comment',
+      ],
+    ])->save();
+    FieldConfig::create([
+      'entity_type' => 'node',
+      'bundle' => 'article',
+      'field_name' => 'comment',
+      'label' => 'Comments',
+      'default_value' => [
+        [
+          'status' => CommentItemInterface::OPEN,
+        ],
+      ],
+    ])->save();
+    \Drupal::service('entity_display.repository')
+      ->getFormDisplay('node', 'article')
+      ->setComponent('comment', [
+        'type' => 'comment_default',
+        'weight' => 20,
+      ])
+      ->save();
+    \Drupal::service('entity_display.repository')
+      ->getViewDisplay('node', 'article')
+      ->setComponent('comment', [
+        'label' => 'above',
+        'type' => 'comment_default',
+        'weight' => 20,
+        'settings' => ['view_mode' => 'full'],
+      ])
+      ->save();
   }
 
   /**


### PR DESCRIPTION
## Summary
- create a `comment` type in tests
- attach a comment field to the `article` node type so comments can be created

## Testing
- `composer install`
- `phpunit -c phpunit.xml.dist tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873cdfab15083319e203ba7f073ac08