### PR TITLE
Add cron-phase and manageUsage tests

### DIFF
--- a/tests/src/Kernel/FileLinkUsageCronPhaseTest.php
+++ b/tests/src/Kernel/FileLinkUsageCronPhaseTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+
+/**
+ * Verifies cron scanning phases across multiple runs.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageCronPhaseTest extends FileLinkUsageKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'filelink_usage',
+  ];
+
+  /**
+   * Tests cron scan phases populate and clean up usage.
+   */
+  public function testCronScanPhases(): void {
+    $uri = 'public://cron_phase.txt';
+    $body = '<a href="/sites/default/files/cron_phase.txt">Download</a>';
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Cron phases',
+      'body' => [
+        'value' => $body,
+        'format' => 'basic_html',
+      ],
+    ]);
+    $node->save();
+
+    $manager = $this->container->get('filelink_usage.manager');
+    $database = $this->container->get('database');
+
+    // First pass - matches recorded but usage missing until file exists.
+    $manager->runCron();
+    $link = $database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
+      ->execute()
+      ->fetchField();
+    $this->assertEquals($uri, $link);
+    $count = $database->select('file_usage')->countQuery()->execute()->fetchField();
+    $this->assertEquals(0, $count);
+
+    // Create managed file and run cron again - usage should be recorded.
+    file_put_contents(
+      $this->container->get('file_system')->realpath($uri),
+      'txt'
+    );
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'cron_phase.txt',
+    ]);
+    $file->save();
+    $manager->runCron();
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertArrayHasKey($node->id(), $usage['filelink_usage']['node']);
+
+    // Remove the link and run cron a third time - usage removed.
+    $node->set('body', [
+      'value' => 'No link here',
+      'format' => 'basic_html',
+    ]);
+    $node->save();
+    $manager->runCron();
+    $count = $database->select('filelink_usage_matches')
+      ->countQuery()->execute()->fetchField();
+    $this->assertEquals(0, $count);
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertEmpty($usage['filelink_usage']['node'] ?? []);
+  }
+
+}

--- a/tests/src/Kernel/FileLinkUsageFileHooksTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileHooksTest.php
@@ -69,8 +69,6 @@ class FileLinkUsageFileHooksTest extends FileLinkUsageKernelTestBase {
       'filename' => 'hook_file.txt',
     ]);
     $file->save();
-    $this->container->get('filelink_usage.scanner')
-      ->scan(['node' => [$node->id()]]);
 
     $usage = $this->container->get('file.usage')->listUsage($file);
     $this->assertArrayHasKey($node->id(), $usage['filelink_usage']['node']);

--- a/tests/src/Kernel/FileLinkUsageFileInsertBehaviorTest.php
+++ b/tests/src/Kernel/FileLinkUsageFileInsertBehaviorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+
+/**
+ * Ensures file insert adds usage for saved links exactly once.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageFileInsertBehaviorTest extends FileLinkUsageKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'filelink_usage',
+  ];
+
+  /**
+   * File insert hook registers usage once for existing matches.
+   */
+  public function testFileInsertAddsUsageOnce(): void {
+    $uri = 'public://insert_once.txt';
+    $body = '<a href="/sites/default/files/insert_once.txt">Download</a>';
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Insert once',
+      'body' => [
+        'value' => $body,
+        'format' => 'basic_html',
+      ],
+    ]);
+    $node->save();
+
+    // Scan to populate matches without a managed file.
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
+    $database = $this->container->get('database');
+    $count = $database->select('file_usage')->countQuery()->execute()->fetchField();
+    $this->assertEquals(0, $count);
+
+    // Create file - insert hook should add usage automatically.
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'txt');
+    $file = File::create(['uri' => $uri, 'filename' => 'insert_once.txt']);
+    $file->save();
+
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertCount(1, $usage['filelink_usage']['node']);
+    $this->assertArrayHasKey($node->id(), $usage['filelink_usage']['node']);
+
+    // Rescanning should not duplicate usage entries.
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertCount(1, $usage['filelink_usage']['node']);
+  }
+
+}

--- a/tests/src/Kernel/FileLinkUsageManageUsageTest.php
+++ b/tests/src/Kernel/FileLinkUsageManageUsageTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+
+/**
+ * Tests manageUsage() via save and delete hooks.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageManageUsageTest extends FileLinkUsageKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'filelink_usage',
+  ];
+
+  /**
+   * Updating a node triggers manageUsage via presave.
+   */
+  public function testNodePresaveUpdatesUsage(): void {
+    $uri1 = 'public://manage1.txt';
+    $uri2 = 'public://manage2.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri1), 'txt');
+    file_put_contents($this->container->get('file_system')->realpath($uri2), 'txt');
+    $file1 = File::create(['uri' => $uri1, 'filename' => 'manage1.txt']);
+    $file1->save();
+    $file2 = File::create(['uri' => $uri2, 'filename' => 'manage2.txt']);
+    $file2->save();
+
+    $body = '<a href="/sites/default/files/manage1.txt">Download</a>';
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Manage',
+      'body' => [
+        'value' => $body,
+        'format' => 'basic_html',
+      ],
+    ]);
+    $node->save();
+
+    // Initial scan records usage for the first file.
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
+    $usage1 = $this->container->get('file.usage')->listUsage($file1);
+    $this->assertArrayHasKey($node->id(), $usage1['filelink_usage']['node']);
+
+    // Update node to link to the second file and save.
+    $node->set('body', [
+      'value' => '<a href="/sites/default/files/manage2.txt">Download</a>',
+      'format' => 'basic_html',
+    ]);
+    $node->save();
+
+    // Usage should now reference file2 without rescanning.
+    $usage1 = $this->container->get('file.usage')->listUsage($file1);
+    $this->assertEmpty($usage1['filelink_usage']['node'] ?? []);
+    $usage2 = $this->container->get('file.usage')->listUsage($file2);
+    $this->assertArrayHasKey($node->id(), $usage2['filelink_usage']['node']);
+  }
+
+  /**
+   * Deleting a node removes usage via delete hook.
+   */
+  public function testNodeDeleteRemovesUsage(): void {
+    $uri = 'public://manage_delete.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'txt');
+    $file = File::create(['uri' => $uri, 'filename' => 'manage_delete.txt']);
+    $file->save();
+
+    $body = '<a href="/sites/default/files/manage_delete.txt">Download</a>';
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Delete',
+      'body' => [
+        'value' => $body,
+        'format' => 'basic_html',
+      ],
+    ]);
+    $node->save();
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
+
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertArrayHasKey($node->id(), $usage['filelink_usage']['node']);
+
+    $node->delete();
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertEmpty($usage['filelink_usage']['node'] ?? []);
+    $count = $this->container->get('database')->select('filelink_usage_matches')
+      ->countQuery()->execute()->fetchField();
+    $this->assertEquals(0, $count);
+  }
+
+}


### PR DESCRIPTION
## Summary
- add test covering cron scanning phases
- test manageUsage on node save/delete hooks
- test file insert hook adds usage exactly once
- update existing file insert hook test for new behavior

## Testing
- `phpunit tests/src/Kernel` *(fails: FileLinkUsageKernelTestBase not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c92b918c833185fed690ed3e53bf