### PR TITLE
Implement filelink_usage_install hook

### DIFF
--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -68,6 +68,28 @@ function filelink_usage_schema() {
 }
 
 /**
+ * Implements hook_install().
+ */
+function filelink_usage_install(): void {
+  $schema = \Drupal::database()->schema();
+
+  $tables = [
+    'node_field_data',
+    'block_content_field_data',
+    'taxonomy_term_field_data',
+    'comment_field_data',
+  ];
+
+  foreach ($tables as $table) {
+    if (!$schema->tableExists($table)) {
+      return;
+    }
+  }
+
+  \Drupal::service('filelink_usage.manager')->runCron();
+}
+
+/**
  * Implements hook_uninstall().
  */
 function filelink_usage_uninstall() {


### PR DESCRIPTION
## Summary
- trigger an initial scan via FileLinkUsageManager when installing the module
- guard against missing entity tables

## Testing
- `php -l filelink_usage.install`
- `phpunit tests/src/Kernel/FileLinkUsageCronPhaseTest.php` *(fails: Class not found)*

------
https://chatgpt.com/codex/tasks/task_e_687503adb6008331a740c1ad52895143