### PR TITLE
Add unit test for Drush command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,8 @@
   ],
   "require": {
     "php": "^8.1"
+  },
+  "require-dev": {
+    "drush/drush": "^13.6"
   }
 }

--- a/tests/src/Unit/FileLinkUsageCommandsTest.php
+++ b/tests/src/Unit/FileLinkUsageCommandsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\filelink_usage\Unit;
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+require_once __DIR__ . '/../../../src/FileLinkUsageManager.php';
+require_once __DIR__ . '/../../../src/Commands/FileLinkUsageCommands.php';
+
+use Drupal\filelink_usage\Commands\FileLinkUsageCommands;
+use Drupal\filelink_usage\FileLinkUsageManager;
+use PHPUnit\Framework\TestCase;
+use Drush\Log\DrushLoggerManager;
+
+class FileLinkUsageCommandsTest extends TestCase {
+    public function testScanInvokesRunCron(): void {
+        $manager = $this->createMock(FileLinkUsageManager::class);
+        $manager->expects($this->once())
+            ->method('runCron');
+
+        $command = new FileLinkUsageCommands($manager);
+        $command->setLogger(new DrushLoggerManager());
+
+        $command->scan();
+    }
+}


### PR DESCRIPTION
## Summary
- add a PHPUnit unit test for the Drush command
- include drush/drush as a dev dependency to support the unit test

## Testing
- `phpunit tests/src/Unit/FileLinkUsageCommandsTest.php`
- `phpunit tests/src/Kernel/FileLinkUsageBlockContentHooksTest.php` *(fails: Class "Drupal\KernelTests\KernelTestBase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687505d64a2c8331b01e1120c46f1301