### PR TITLE
Invalidate entity_list:file cache when file usage changes

### DIFF
--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -298,6 +298,7 @@ class FileLinkUsageManager {
 
     if ($file_ids) {
       $tags = array_map(fn(int $id) => "file:$id", array_unique($file_ids));
+      $tags[] = 'entity_list:file';
       \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
     }
   }
@@ -451,6 +452,7 @@ class FileLinkUsageManager {
 
     if ($file_ids) {
       $tags = array_map(fn(int $id) => "file:$id", array_unique($file_ids));
+      $tags[] = 'entity_list:file';
       \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
     }
   }

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -60,6 +60,7 @@ class FileLinkUsageScanner {
     // Invalidate file cache tags for all changed files in one operation.
     if (!empty($changedFileIds)) {
       $tags = array_map(fn($fid) => "file:$fid", array_unique($changedFileIds));
+      $tags[] = 'entity_list:file';
       \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
     }
   }


### PR DESCRIPTION
## Summary
- clear entity_list:file cache tag alongside individual file tags

## Testing
- `php -l src/FileLinkUsageManager.php`
- `php -l src/FileLinkUsageScanner.php`
- `vendor/bin/phpunit -c phpunit.xml.dist` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68751c0806e483318c6b5c230a790b89