### PR TITLE
Improve URL normalization for file links

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -102,6 +102,7 @@ function filelink_usage_mark_for_rescan(NodeInterface $node): void {
  */
 function _filelink_usage_extract_uris(EntityInterface $entity): array {
   $uris = [];
+  $normalizer = \Drupal::service('filelink_usage.normalizer');
   foreach ($entity->getFieldDefinitions() as $field_name => $definition) {
     $type = $definition->getType();
     if (!in_array($type, ['text', 'text_long', 'text_with_summary', 'string_long'], TRUE)) {
@@ -117,14 +118,7 @@ function _filelink_usage_extract_uris(EntityInterface $entity): array {
       }
       preg_match_all('/(?:src|href)="([^"]*\\/(?:sites\\/default\\/files|system\\/files)\\/[^"]+)"/i', $text, $matches);
       foreach ($matches[1] ?? [] as $url) {
-        $uri = $url;
-        if (str_contains($url, '/sites/default/files/')) {
-          $uri = 'public://' . explode('/sites/default/files/', preg_replace('/^https?:\\/\\//', '', $url), 2)[1];
-        }
-        elseif (str_contains($url, '/system/files/')) {
-          $uri = 'private://' . explode('/system/files/', preg_replace('/^https?:\\/\\//', '', $url), 2)[1];
-        }
-        $uris[] = $uri;
+        $uris[] = $normalizer->normalize($url);
       }
     }
   }

--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -21,6 +21,7 @@ services:
       - '@config.factory'
       - '@datetime.time'
       - '@logger.channel.filelink_usage'
+      - '@filelink_usage.normalizer'
 
   filelink_usage.normalizer:
     class: Drupal\filelink_usage\FileLinkUsageNormalizer

--- a/src/FileLinkUsageNormalizer.php
+++ b/src/FileLinkUsageNormalizer.php
@@ -5,14 +5,44 @@ declare(strict_types=1);
 namespace Drupal\filelink_usage;
 
 /**
- * No‑op normalizer (placeholder for future logic).
+ * Normalizes file links found in HTML.
  */
 class FileLinkUsageNormalizer {
 
   /**
-   * Return the URI unchanged for now.
+   * Normalize a file link to a Drupal stream URI.
+   *
+   * @param string $uri
+   *   The raw link extracted from HTML.
+   *
+   * @return string
+   *   The normalized URI (public:// or private:// where possible).
    */
   public function normalize(string $uri): string {
+    // Remove query strings and fragments.
+    $uri = preg_replace('/[#?].*/', '', $uri);
+
+    // Collapse duplicate slashes.
+    $uri = preg_replace('#/+#', '/', $uri);
+
+    // Remove trailing /index or /index.html type suffixes.
+    $uri = preg_replace('#/index(?:\.html?)?$#i', '', $uri);
+
+    $public = '/sites/default/files/';
+    $private = '/system/files/';
+
+    if (str_contains($uri, $public)) {
+      $path = preg_replace('#^https?://[^/]+#', '', $uri);
+      $path = explode($public, $path, 2)[1] ?? '';
+      return 'public://' . ltrim($path, '/');
+    }
+
+    if (str_contains($uri, $private)) {
+      $path = preg_replace('#^https?://[^/]+#', '', $uri);
+      $path = explode($private, $path, 2)[1] ?? '';
+      return 'private://' . ltrim($path, '/');
+    }
+
     return $uri;
   }
 

--- a/tests/src/Unit/FileLinkUsageNormalizerTest.php
+++ b/tests/src/Unit/FileLinkUsageNormalizerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\filelink_usage\Unit;
+
+require_once __DIR__ . '/../../../src/FileLinkUsageNormalizer.php';
+
+use Drupal\filelink_usage\FileLinkUsageNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class FileLinkUsageNormalizerTest extends TestCase {
+    public function testUrlNormalization(): void {
+        $normalizer = new FileLinkUsageNormalizer();
+        $url = 'https://dev.example.com/sites/default/files/foo/bar.pdf?x=1#sec';
+        $this->assertEquals('public://foo/bar.pdf', $normalizer->normalize($url));
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement full normalizer for hard coded URLs
- call normalizer from helper and scanner
- inject normalizer into scanner service
- cover normalization with new unit test

## Testing
- `php -l src/FileLinkUsageNormalizer.php`
- `php -l filelink_usage.module`
- `php -l src/FileLinkUsageScanner.php`
- `php -l tests/src/Unit/FileLinkUsageNormalizerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68754d772d448331ba4860dafbaeff87