### PR TITLE
Support single quoted links

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -116,8 +116,8 @@ function _filelink_usage_extract_uris(EntityInterface $entity): array {
       if ($text === '') {
         continue;
       }
-      preg_match_all('/(?:src|href)="([^"]*\\/(?:sites\\/default\\/files|system\\/files)\\/[^"]+)"/i', $text, $matches);
-      foreach ($matches[1] ?? [] as $url) {
+      preg_match_all('/(?:src|href)=(["\'])([^"\']*\\/(?:sites\\/default\\/files|system\\/files)\\/[^"\']+)\1/i', $text, $matches);
+      foreach ($matches[2] ?? [] as $url) {
         $uris[] = $normalizer->normalize($url);
       }
     }

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -197,8 +197,8 @@ class FileLinkUsageScanner {
     $view_builder = $this->entityTypeManager->getViewBuilder($entity_type);
     $build = $view_builder->view($entity, 'full');
     $html = (string) $this->renderer->renderInIsolation($build);
-    preg_match_all('/(?:src|href)="([^"]*\\/(?:sites\\/default\\/files|system\\/files)\\/[^"]+)"/i', $html, $matches);
-    $file_urls = $matches[1] ?? [];
+    preg_match_all('/(?:src|href)=(["\'])([^"\']*\\/(?:sites\\/default\\/files|system\\/files)\\/[^"\']+)\1/i', $html, $matches);
+    $file_urls = $matches[2] ?? [];
 
     // Track found file URIs and avoid counting duplicates within this entity.
     $found_uris = [];

--- a/tests/src/Kernel/FileLinkUsageManageUsageTest.php
+++ b/tests/src/Kernel/FileLinkUsageManageUsageTest.php
@@ -70,6 +70,31 @@ class FileLinkUsageManageUsageTest extends FileLinkUsageKernelTestBase {
   }
 
   /**
+   * Single-quoted links are extracted during presave.
+   */
+  public function testNodePresaveSingleQuotedLink(): void {
+    $uri = 'public://single_presave.txt';
+    file_put_contents($this->container->get('file_system')->realpath($uri), 'txt');
+    $file = File::create(['uri' => $uri, 'filename' => 'single_presave.txt']);
+    $file->save();
+
+    $body = "<a href='/sites/default/files/single_presave.txt'>Download</a>";
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Presave single',
+      'body' => [
+        'value' => $body,
+        'format' => 'basic_html',
+      ],
+    ]);
+    $node->save();
+
+    // Saving the node should record usage via presave without scanning.
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertArrayHasKey($node->id(), $usage['filelink_usage']['node']);
+  }
+
+  /**
    * Deleting a node removes usage via delete hook.
    */
   public function testNodeDeleteRemovesUsage(): void {


### PR DESCRIPTION
## Summary
- allow regex to match file URLs wrapped in single or double quotes
- add kernel test to scan single-quoted links
- add kernel test to verify presave extraction with single quotes

## Testing
- `php -l src/FileLinkUsageScanner.php`
- `php -l filelink_usage.module`
- `php -l tests/src/Kernel/FileLinkUsageScannerTest.php`
- `php -l tests/src/Kernel/FileLinkUsageManageUsageTest.php`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687554ad1e0483319fd6eebff3856fc7