### PR TITLE
Replace custom file cache tag

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -171,7 +171,7 @@ function _filelink_usage_cleanup_deleted(string $type, int $id, EntityTypeManage
     ->reconcileEntityUsage($target_type, $id, TRUE);
 
   $tags = array_map(fn(int $fid) => "file:$fid", array_unique($file_ids));
-  $tags[] = 'entity_list:file';
+  $tags[] = 'file_list';
   \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
 }
 

--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -299,7 +299,7 @@ class FileLinkUsageManager {
 
     if ($file_ids) {
       $tags = array_map(fn(int $id) => "file:$id", array_unique($file_ids));
-      $tags[] = 'entity_list:file';
+      $tags[] = 'file_list';
       \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
     }
   }
@@ -465,7 +465,7 @@ class FileLinkUsageManager {
 
     if ($file_ids) {
       $tags = array_map(fn(int $id) => "file:$id", array_unique($file_ids));
-      $tags[] = 'entity_list:file';
+      $tags[] = 'file_list';
       \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
     }
   }

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -63,7 +63,7 @@ class FileLinkUsageScanner {
     // Invalidate file cache tags for all changed files in one operation.
     if (!empty($changedFileIds)) {
       $tags = array_map(fn($fid) => "file:$fid", array_unique($changedFileIds));
-      $tags[] = 'entity_list:file';
+      $tags[] = 'file_list';
       \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
     }
   }

--- a/tests/src/Kernel/FileLinkUsageDeletionCacheTest.php
+++ b/tests/src/Kernel/FileLinkUsageDeletionCacheTest.php
@@ -90,7 +90,7 @@ class FileLinkUsageDeletionCacheTest extends FileLinkUsageKernelTestBase {
     $node->delete();
 
     $this->assertContains('file:' . $file->id(), $this->invalidated);
-    $this->assertContains('entity_list:file', $this->invalidated);
+    $this->assertContains('file_list', $this->invalidated);
   }
 
 }


### PR DESCRIPTION
## Summary
- use default `file_list` cache tag instead of `entity_list:file`
- update tests to match new cache tag

## Testing
- `php -l src/FileLinkUsageManager.php`
- `php -l src/FileLinkUsageScanner.php`
- `php -l filelink_usage.module`
- `php -l tests/src/Kernel/FileLinkUsageDeletionCacheTest.php`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68757ad919988331ba325f5f5f37a5ba