### PR TITLE
Inject cache tag invalidator

### DIFF
--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -22,6 +22,7 @@ services:
       - '@datetime.time'
       - '@logger.channel.filelink_usage'
       - '@filelink_usage.normalizer'
+      - '@cache_tags.invalidator'
 
   filelink_usage.normalizer:
     class: Drupal\filelink_usage\FileLinkUsageNormalizer
@@ -36,3 +37,4 @@ services:
       - '@file.usage'
       - '@entity_type.manager'
       - '@filelink_usage.normalizer'
+      - '@cache_tags.invalidator'


### PR DESCRIPTION
## Summary
- inject `CacheTagsInvalidatorInterface` into `FileLinkUsageScanner` and `FileLinkUsageManager`
- use injected service instead of `\Drupal::service()`
- pass the cache invalidator service via `filelink_usage.services.yml`

## Testing
- `composer install` *(fails: vendor not present, cannot run tests)*

------
https://chatgpt.com/codex/tasks/task_e_68757c3488208331b762a7908e45d3b6