### PR TITLE
Add PHPUnit configuration for module tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,21 +81,14 @@ Once installed and configured, Filelink Usage works mostly behind the scenes to 
 
 ## Testing
 
-Kernel tests for this module are located in `tests/src/Kernel`. You will need a Drupal installation with PHPUnit configured. Copy `core/phpunit.xml.dist` to `phpunit.xml` in the Drupal root and update the database settings.
-
-Run the tests with PHPUnit:
+Kernel and unit tests are located under `tests/src`. Install the development dependencies first and run PHPUnit using the included configuration file.
 
 ```bash
-vendor/bin/phpunit -c core modules/custom/filelink_usage/tests/src/Kernel
+composer install --dev
+vendor/bin/phpunit
 ```
 
-Or via Drush:
-
-```bash
-drush phpunit -- modules/custom/filelink_usage/tests/src/Kernel
-```
-
-These kernel tests verify the scanner hooks and full scan behavior.
+These tests verify the scanner hooks and overall module behaviour.
 ## Cron Behavior
 
 Drupal’s Cron plays a key role in ongoing maintenance of file link usage data. On each cron run, `filelink_usage` checks if any content needs to be rescanned based on the configured frequency:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "php": "^8.1"
   },
   "require-dev": {
-    "drush/drush": "^13.6"
+    "drush/drush": "^13.6",
+    "phpunit/phpunit": "^10",
+    "drupal/core-recommended": "^10",
+    "drupal/core-dev": "^10"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/drupal/core/tests/bootstrap.php" colors="true">
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="filelink_usage">
+      <directory>./tests/src</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- include Drupal core dev dependencies and PHPUnit in `composer.json`
- add `phpunit.xml.dist` for running module tests
- document how to run tests

## Testing
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_68757dd60fd48331a043f5bb1863a422