### PR TITLE
Improve file extraction error handling

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -100,7 +100,7 @@ function filelink_usage_mark_for_rescan(NodeInterface $node): void {
 /**
  * Extract file URIs from all text fields of an entity.
  */
-function _filelink_usage_extract_uris(EntityInterface $entity): array {
+function _filelink_usage_extract_uris(EntityInterface $entity): ?array {
   $uris = [];
   $normalizer = \Drupal::service('filelink_usage.normalizer');
   foreach ($entity->getFieldDefinitions() as $field_name => $definition) {
@@ -116,9 +116,27 @@ function _filelink_usage_extract_uris(EntityInterface $entity): array {
       if ($text === '') {
         continue;
       }
-      preg_match_all('/(?:src|href)=(["\'])([^"\']*\\/(?:sites\\/default\\/files|system\\/files)\\/[^"\']+)\1/i', $text, $matches);
-      foreach ($matches[2] ?? [] as $url) {
-        $uris[] = $normalizer->normalize($url);
+      $dom = new \DOMDocument();
+      libxml_use_internal_errors(TRUE);
+      $loaded = $dom->loadHTML('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $text, LIBXML_NOWARNING | LIBXML_NOERROR);
+      $errors = libxml_get_errors();
+      libxml_clear_errors();
+      libxml_use_internal_errors(FALSE);
+      if (!$loaded || !empty($errors)) {
+        \Drupal::logger('filelink_usage')->error('Failed parsing HTML in %type %id field %field.', [
+          '%type' => $entity->getEntityTypeId(),
+          '%id' => $entity->id(),
+          '%field' => $field_name,
+        ]);
+        return NULL;
+      }
+      $xpath = new \DOMXPath($dom);
+      foreach ($xpath->query('//*[@href]|//*[@src]') as $node) {
+        $attr = $node->hasAttribute('href') ? 'href' : 'src';
+        $url = $node->getAttribute($attr);
+        if (preg_match('#/(?:sites/default/files|system/files)/#i', $url)) {
+          $uris[] = $normalizer->normalize($url);
+        }
       }
     }
   }
@@ -134,7 +152,11 @@ function _filelink_usage_manage_presave(EntityInterface $entity): void {
     return;
   }
   $uris = _filelink_usage_extract_uris($entity);
-  \Drupal::service('filelink_usage.manager')->manageUsage($entity->getEntityTypeId(), $id, $uris);
+  if ($uris === NULL) {
+    return;
+  }
+  \Drupal::service('filelink_usage.manager')
+    ->manageUsage($entity->getEntityTypeId(), $id, $uris);
 }
 
 /**

--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -204,7 +204,10 @@ class FileLinkUsageManager {
    * @param array $uris
    *   List of file URIs to register.
    */
-  public function manageUsage(string $entity_type, int $entity_id, array $uris): void {
+  public function manageUsage(string $entity_type, int $entity_id, ?array $uris): void {
+    if ($uris === NULL) {
+      return;
+    }
     $table = $this->matchesHasEntityColumns
       ? 'filelink_usage_matches' : 'filelink_usage';
 

--- a/tests/src/Kernel/FileLinkUsageLargeContentTest.php
+++ b/tests/src/Kernel/FileLinkUsageLargeContentTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+
+/**
+ * Ensures large content does not lose usage entries on save.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageLargeContentTest extends FileLinkUsageKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'filelink_usage',
+  ];
+
+  protected MutableTime $time;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->time = new MutableTime(1000);
+    $this->container->set('datetime.time', $this->time);
+  }
+
+  /**
+   * Saving large bodies updates timestamps without deleting usage.
+   */
+  public function testLargeContentPresave(): void {
+    $fs = $this->container->get('file_system');
+    $links = [];
+    $body = [];
+    $count = 200;
+    for ($i = 1; $i <= $count; $i++) {
+      $uri = "public://large{$i}.txt";
+      file_put_contents($fs->realpath($uri), 'txt');
+      $file = File::create([
+        'uri' => $uri,
+        'filename' => "large{$i}.txt",
+      ]);
+      $file->save();
+      $links[] = $file;
+      $body[] = "<a href=\"/sites/default/files/large{$i}.txt\">L{$i}</a>";
+    }
+
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Large',
+      'body' => ['value' => implode(' ', $body), 'format' => 'basic_html'],
+    ]);
+    $node->save();
+
+    $this->container->get('filelink_usage.scanner')->scan(['node' => [$node->id()]]);
+
+    $database = $this->container->get('database');
+    $match_count = $database->select('filelink_usage_matches', 'f')
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
+      ->countQuery()->execute()->fetchField();
+    $this->assertEquals($count, $match_count);
+
+    $this->time->setTime(2000);
+    $node->set('body', ['value' => implode(' ', $body), 'format' => 'basic_html']);
+    $node->save();
+
+    $rows = $database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link', 'timestamp'])
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
+      ->execute()->fetchAllKeyed();
+    $this->assertCount($count, $rows);
+    foreach ($rows as $timestamp) {
+      $this->assertEquals(2000, (int) $timestamp);
+    }
+
+    $usage_count = $database->select('file_usage')
+      ->countQuery()->execute()->fetchField();
+    $this->assertEquals($count, (int) $usage_count);
+  }
+}


### PR DESCRIPTION
## Summary
- use DOMDocument in `_filelink_usage_extract_uris()` and log parse errors
- skip usage management when extraction fails
- support `NULL` URI lists in `FileLinkUsageManager::manageUsage`
- test large content handling

## Testing
- `composer install --no-interaction --prefer-dist`
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: Test directory "././tests/src" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687611bf1f488331b45f47da8a6a9748