### PR TITLE
Fix encoded stream URIs in normalizer

### DIFF
--- a/src/FileLinkUsageNormalizer.php
+++ b/src/FileLinkUsageNormalizer.php
@@ -45,6 +45,16 @@ class FileLinkUsageNormalizer {
       return 'private://' . ltrim($path, '/');
     }
 
+    if (str_starts_with($uri, 'public://')) {
+      $path = rawurldecode(substr($uri, strlen('public://')));
+      return 'public://' . ltrim($path, '/');
+    }
+
+    if (str_starts_with($uri, 'private://')) {
+      $path = rawurldecode(substr($uri, strlen('private://')));
+      return 'private://' . ltrim($path, '/');
+    }
+
     return $uri;
   }
 

--- a/tests/src/Unit/FileLinkUsageNormalizerTest.php
+++ b/tests/src/Unit/FileLinkUsageNormalizerTest.php
@@ -27,5 +27,11 @@ class FileLinkUsageNormalizerTest extends TestCase {
         $url = 'public://existing/file.pdf';
         $this->assertEquals('public://existing/file.pdf', $normalizer->normalize($url));
     }
+
+    public function testEncodedStreamWrapperPath(): void {
+        $normalizer = new FileLinkUsageNormalizer();
+        $url = 'public://Some%20File.pdf';
+        $this->assertEquals('public://Some File.pdf', $normalizer->normalize($url));
+    }
 }
 


### PR DESCRIPTION
## Summary
- update normalizer to decode `public://` and `private://` paths
- add a unit test for encoded stream wrapper paths

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_68762d0562d483318ab49c43cf77ba50