### PR TITLE
Add kernel testsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,19 @@ Once installed and configured, Filelink Usage works mostly behind the scenes to 
 
 ## Testing
 
-Kernel and unit tests are located under `tests/src`. Install the development dependencies first and run PHPUnit using the included configuration file.
+Kernel and unit tests are located under `tests/src`. Install the development
+dependencies first and run PHPUnit with the provided configuration file.
 
 ```bash
 composer install --dev
-vendor/bin/phpunit
+vendor/bin/phpunit -c phpunit.xml.dist
+```
+
+To run a specific suite use the `--testsuite` option:
+
+```bash
+vendor/bin/phpunit --testsuite filelink_usage_unit -c phpunit.xml.dist
+vendor/bin/phpunit --testsuite filelink_usage_kernel -c phpunit.xml.dist
 ```
 
 These tests verify the scanner hooks and overall module behaviour.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,11 @@
     <ini name="error_reporting" value="-1"/>
   </php>
   <testsuites>
-    <testsuite name="filelink_usage">
+    <testsuite name="filelink_usage_unit">
       <directory>./tests/src/Unit</directory>
+    </testsuite>
+    <testsuite name="filelink_usage_kernel">
+      <directory>./tests/src/Kernel</directory>
     </testsuite>
   </testsuites>
 </phpunit>


### PR DESCRIPTION
## Summary
- add `filelink_usage_kernel` testsuite to phpunit config
- update README with commands for running unit and kernel tests

## Testing
- `vendor/bin/phpunit --testsuite filelink_usage_unit -c phpunit.xml.dist`
- `vendor/bin/phpunit --testsuite filelink_usage_kernel -c vendor/drupal/core/phpunit.xml.dist` *(fails: cannot open autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_687637e8420c8331a38167f219cccdf0