### PR TITLE
Ensure cache tags update on new entity insert

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -41,9 +41,13 @@ function filelink_usage_entity_insert(EntityInterface $entity): void {
       break;
 
     default:
-      // Newly created content may contain hard‑coded links – rescan next cron.
       $entity_type = $entity->getEntityType();
       if ($entity_type instanceof ContentEntityTypeInterface) {
+        // Immediately register any detected file links just like presave hooks
+        // do for existing entities so file usage counts update right away.
+        _filelink_usage_manage_presave($entity);
+        // Also mark for a future rescan in case new files matching the links
+        // are uploaded later.
         $manager->markEntityForScan($entity->getEntityTypeId(), $entity->id());
       }
   }

--- a/tests/src/Kernel/FileLinkUsageInsertCacheTest.php
+++ b/tests/src/Kernel/FileLinkUsageInsertCacheTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+
+/**
+ * Ensures cache tags are invalidated when a node is created.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageInsertCacheTest extends FileLinkUsageKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'filelink_usage',
+  ];
+
+  /**
+   * Collected invalidated cache tags.
+   */
+  protected array $invalidated = [];
+
+  /**
+   * Helper to record invalidated tags.
+   */
+  public function recordInvalidatedTags(array $tags): void {
+    $this->invalidated = array_merge($this->invalidated, $tags);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->invalidated = [];
+    $invalidator = new class($this) implements CacheTagsInvalidatorInterface {
+      private $test;
+      public function __construct($test) { $this->test = $test; }
+      public function invalidateTags(array $tags): void { $this->test->recordInvalidatedTags($tags); }
+      public function invalidateTagsAsynchronously(array $tags): void { $this->invalidateTags($tags); }
+    };
+    $this->container->set('cache_tags.invalidator', $invalidator);
+  }
+
+  /**
+   * Saving a new node invalidates cache tags for its linked files.
+   */
+  public function testInsertInvalidatesTags(): void {
+    $uri = 'public://insert_cache.txt';
+    file_put_contents(
+      $this->container->get('file_system')->realpath($uri),
+      'txt'
+    );
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'insert_cache.txt',
+    ]);
+    $file->save();
+
+    $body = '<a href="/sites/default/files/insert_cache.txt">Download</a>';
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Insert cache',
+      'body' => [
+        'value' => $body,
+        'format' => 'basic_html',
+      ],
+    ]);
+    $node->save();
+
+    // Usage should be recorded and cache tags invalidated.
+    $this->assertContains('file:' . $file->id(), $this->invalidated);
+    $this->assertContains('file_list', $this->invalidated);
+  }
+
+}


### PR DESCRIPTION
## Summary
- clear file usage cache tags when creating new entities
- add test covering node insert cache invalidation

## Testing
- `composer install -n` *(fails: tbachert/spi plugin blocked)*
- `vendor/bin/phpunit -c vendor/drupal/core/phpunit.xml.dist tests/src/Kernel/FileLinkUsageInsertCacheTest.php` *(fails: missing autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68763f2844388331b9ce9e96723cbc05