### PR TITLE
Fix scan with comment module disabled

### DIFF
--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -334,14 +334,30 @@ class FileLinkUsageManager {
    * ---------------------------------------------------------------------- */
 
   private function collectAllEntityIds(): array {
-    $nids = $this->database->select('node_field_data', 'n')
-      ->fields('n', ['nid'])->execute()->fetchCol();
-    $bids = $this->database->select('block_content_field_data', 'b')
-      ->fields('b', ['id'])->execute()->fetchCol();
-    $tids = $this->database->select('taxonomy_term_field_data', 't')
-      ->fields('t', ['tid'])->execute()->fetchCol();
-    $cids = $this->database->select('comment_field_data', 'c')
-      ->fields('c', ['cid'])->execute()->fetchCol();
+    $nids = [];
+    if ($this->database->schema()->tableExists('node_field_data')) {
+      $nids = $this->database->select('node_field_data', 'n')
+        ->fields('n', ['nid'])->execute()->fetchCol();
+    }
+
+    $bids = [];
+    if ($this->database->schema()->tableExists('block_content_field_data')) {
+      $bids = $this->database->select('block_content_field_data', 'b')
+        ->fields('b', ['id'])->execute()->fetchCol();
+    }
+
+    $tids = [];
+    if ($this->database->schema()->tableExists('taxonomy_term_field_data')) {
+      $tids = $this->database->select('taxonomy_term_field_data', 't')
+        ->fields('t', ['tid'])->execute()->fetchCol();
+    }
+
+    $cids = [];
+    if ($this->database->schema()->tableExists('comment_field_data')) {
+      $cids = $this->database->select('comment_field_data', 'c')
+        ->fields('c', ['cid'])->execute()->fetchCol();
+    }
+
     $pids = [];
     if (\Drupal::service('entity_type.manager')->hasDefinition('paragraph') &&
         $this->database->schema()->tableExists('paragraph')) {

--- a/tests/src/Kernel/FileLinkUsageNoCommentModuleTest.php
+++ b/tests/src/Kernel/FileLinkUsageNoCommentModuleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\Tests\filelink_usage\Kernel;
+
+use Drupal\file\Entity\File;
+use Drupal\node\Entity\Node;
+
+/**
+ * Ensures cron runs without the Comment module enabled.
+ *
+ * @group filelink_usage
+ */
+class FileLinkUsageNoCommentModuleTest extends FileLinkUsageKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'text',
+    'file',
+    'node',
+    'filelink_usage',
+  ];
+
+  /**
+   * Verify runCron works when no comment tables exist.
+   */
+  public function testCronWithoutCommentModule(): void {
+    $uri = 'public://no_comment.txt';
+    file_put_contents(
+      $this->container->get('file_system')->realpath($uri),
+      'txt'
+    );
+    $file = File::create([
+      'uri' => $uri,
+      'filename' => 'no_comment.txt',
+    ]);
+    $file->save();
+
+    $node = Node::create([
+      'type' => 'article',
+      'title' => 'Cron no comment',
+      'body' => [
+        'value' => '<a href="/sites/default/files/no_comment.txt">Download</a>',
+        'format' => 'basic_html',
+      ],
+    ]);
+    $node->save();
+
+    $manager = $this->container->get('filelink_usage.manager');
+    $manager->runCron();
+
+    $database = $this->container->get('database');
+    $link = $database->select('filelink_usage_matches', 'f')
+      ->fields('f', ['link'])
+      ->condition('entity_type', 'node')
+      ->condition('entity_id', $node->id())
+      ->execute()
+      ->fetchField();
+    $this->assertEquals($uri, $link);
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertArrayHasKey($node->id(), $usage['filelink_usage']['node']);
+  }
+
+}


### PR DESCRIPTION
## Summary
- guard against missing `comment_field_data` table in full scan
- add a kernel test ensuring cron works when the Comment module isn't enabled

## Testing
- `./vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_6876645b4818833199b987ecac1a0e18