### PR TITLE
Fix file URI normalization during table comparisons

### DIFF
--- a/filelink_usage.module
+++ b/filelink_usage.module
@@ -184,7 +184,8 @@ function _filelink_usage_cleanup_deleted(string $type, int $id, EntityTypeManage
 
   $file_ids = [];
   foreach ($links as $uri) {
-    $files = $etm->getStorage('file')->loadByProperties(['uri' => $uri]);
+    $normalized = \Drupal::service('filelink_usage.normalizer')->normalize($uri);
+    $files = $etm->getStorage('file')->loadByProperties(['uri' => $normalized]);
     if (!$files) {
       continue;
     }

--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -72,9 +72,10 @@ class FileLinkUsageManager {
     // each referencing entity. Older schema versions may not have the matches
     // table, so guard against that scenario.
     if ($this->database->schema()->tableExists('filelink_usage_matches')) {
+      $normalized = $this->normalizer->normalize($file->getFileUri());
       $query = $this->database->select('filelink_usage_matches', 'f')
         ->fields('f', ['entity_type', 'entity_id'])
-        ->condition('link', $file->getFileUri());
+        ->condition('link', $normalized);
 
       foreach ($query->execute() as $row) {
         $type = $row->entity_type;

--- a/src/FileLinkUsageScanner.php
+++ b/src/FileLinkUsageScanner.php
@@ -152,11 +152,12 @@ class FileLinkUsageScanner {
       if (!$file) {
         continue;
       }
+      $normalized = $this->normalizer->normalize($file->getFileUri());
       $exists = $this->database->select('filelink_usage_matches', 'f')
         ->fields('f', ['id'])
         ->condition('entity_type', $row->type)
         ->condition('entity_id', $row->id)
-        ->condition('link', $file->getFileUri())
+        ->condition('link', $normalized)
         ->execute()
         ->fetchField();
       if (!$exists) {


### PR DESCRIPTION
## Summary
- normalize file URIs from managed files before comparing to tracking tables
- run unit tests

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --configuration phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_68768da5658c8331a480135816aa118b