### PR TITLE
Refactor file finding logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor/
 /composer.lock
+.phpunit.result.cache

--- a/filelink_usage.services.yml
+++ b/filelink_usage.services.yml
@@ -22,10 +22,17 @@ services:
       - '@datetime.time'
       - '@logger.channel.filelink_usage'
       - '@filelink_usage.normalizer'
+      - '@filelink_usage.file_finder'
       - '@cache_tags.invalidator'
 
   filelink_usage.normalizer:
     class: Drupal\filelink_usage\FileLinkUsageNormalizer
+
+  filelink_usage.file_finder:
+    class: Drupal\filelink_usage\FileLinkUsageFileFinder
+    arguments:
+      - '@entity_type.manager'
+      - '@filelink_usage.normalizer'
 
   filelink_usage.manager:
     class: Drupal\filelink_usage\FileLinkUsageManager
@@ -37,4 +44,5 @@ services:
       - '@file.usage'
       - '@entity_type.manager'
       - '@filelink_usage.normalizer'
+      - '@filelink_usage.file_finder'
       - '@cache_tags.invalidator'

--- a/src/FileLinkUsageFileFinder.php
+++ b/src/FileLinkUsageFileFinder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\filelink_usage;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\file\FileInterface;
+
+/**
+ * Helper service to locate managed files by normalized URIs.
+ */
+class FileLinkUsageFileFinder {
+
+  protected EntityTypeManagerInterface $entityTypeManager;
+  protected FileLinkUsageNormalizer $normalizer;
+
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, FileLinkUsageNormalizer $normalizer) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->normalizer = $normalizer;
+  }
+
+  /**
+   * Load a managed file by its normalized URI.
+   */
+  public function loadFileByNormalizedUri(string $uri): ?FileInterface {
+    $files = $this->entityTypeManager->getStorage('file')
+      ->loadByProperties(['uri' => $uri]);
+    if ($files) {
+      return reset($files);
+    }
+    $filename = basename($uri);
+    $candidates = $this->entityTypeManager->getStorage('file')
+      ->loadByProperties(['filename' => $filename]);
+    foreach ($candidates as $candidate) {
+      if ($this->normalizer->normalize($candidate->getFileUri()) === $uri) {
+        return $candidate;
+      }
+    }
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
## Summary
- introduce FileLinkUsageFileFinder service
- inject new helper into FileLinkUsageManager and FileLinkUsageScanner
- use shared helper for file lookups
- ignore PHPUnit cache file

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_6876c2b34a908331b7621f592a1b1c4b