### PR TITLE
Fix MySQL index addition for managed_file_uri

### DIFF
--- a/filelink_usage.install
+++ b/filelink_usage.install
@@ -43,7 +43,8 @@ function filelink_usage_schema() {
       'entity_type' => ['entity_type'],
       'entity_id' => ['entity_id'],
       'link' => ['link'],
-      'managed_file_uri' => ['managed_file_uri'],
+      // Limit index length for compatibility with InnoDB on MySQL.
+      'managed_file_uri' => ['managed_file_uri(191)'],
     ],
     'unique keys' => [
       'entity_link' => ['entity_type', 'entity_id', 'link'],
@@ -250,7 +251,8 @@ function filelink_usage_update_8007() {
       'length' => 1024,
       'not null' => FALSE,
     ]);
-    $schema->addIndex('filelink_usage_matches', 'managed_file_uri', ['managed_file_uri'], []);
+    // Specify index length explicitly for MySQL compatibility.
+    $schema->addIndex('filelink_usage_matches', 'managed_file_uri', ['managed_file_uri(191)']);
 
     /** @var \Drupal\filelink_usage\FileLinkUsageManager $manager */
     $manager = \Drupal::service('filelink_usage.manager');


### PR DESCRIPTION
## Summary
- limit the `managed_file_uri` index length in the schema
- do the same when the column is added during update 8007

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_6876cd77718c833190e75b01ffca5d82