### PR TITLE
Gracefully handle missing tables in cron

### DIFF
--- a/src/FileLinkUsageManager.php
+++ b/src/FileLinkUsageManager.php
@@ -101,6 +101,10 @@ class FileLinkUsageManager {
    * Execute cron scan for entities needing re‑scan.
    */
   public function runCron(): void {
+    // Skip if the module schema has not been installed yet.
+    if (!$this->database->schema()->tableExists('filelink_usage_matches')) {
+      return;
+    }
     $config     = $this->configFactory->getEditable('filelink_usage.settings');
     $frequency  = $config->get('scan_frequency');
     $last_scan  = (int) $config->get('last_scan');


### PR DESCRIPTION
## Summary
- check for filelink_usage tables before running cron

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_6877a99c281c8331a52c267dc601124b